### PR TITLE
Removed star rating from FB's native ad adapter

### DIFF
--- a/FacebookAudienceNetwork/Changelog.md
+++ b/FacebookAudienceNetwork/Changelog.md
@@ -1,4 +1,8 @@
 ## Changelog
+  * 4.28.0.1
+    * This version of the adapters has been certified with Facebook Audience Network 4.28.0.
+	* Removed star rating from the native ad adapter since it has been deprecated by Facebook.
+
   * 4.28.0.0
     * This version of the adapters has been certified with Facebook Audience Network 4.28.0.
     * Updated native adapters to handle the use-case of empty clickable views

--- a/FacebookAudienceNetwork/FacebookNativeAdAdapter.m
+++ b/FacebookAudienceNetwork/FacebookNativeAdAdapter.m
@@ -31,25 +31,11 @@ NSString *const kFBVideoAdsEnabledKey = @"video_enabled";
         _fbNativeAd = fbNativeAd;
         _fbNativeAd.delegate = self;
 
-        NSNumber *starRating = nil;
-
-        // Normalize star rating to 5 stars.
-        if (fbNativeAd.starRating.scale != 0) {
-            CGFloat ratio = 0.0f;
-            ratio = kUniversalStarRatingScale/fbNativeAd.starRating.scale;
-            starRating = [NSNumber numberWithFloat:ratio*fbNativeAd.starRating.value];
-        }
-
         NSMutableDictionary *properties;
         if (adProps) {
             properties = [NSMutableDictionary dictionaryWithDictionary:adProps];
         } else {
             properties = [NSMutableDictionary dictionary];
-        }
-
-
-        if (starRating) {
-            [properties setObject:starRating forKey:kAdStarRatingKey];
         }
 
         if (fbNativeAd.title) {


### PR DESCRIPTION
Removed star rating from the native ad adapter since it has been deprecated by Facebook.