### PR TITLE
Update MPGoogleAdMobRewardedVideoCustomEvent.h

### DIFF
--- a/AdMob/MPGoogleAdMobRewardedVideoCustomEvent.h
+++ b/AdMob/MPGoogleAdMobRewardedVideoCustomEvent.h
@@ -1,9 +1,9 @@
+#if __has_include(<MoPub/MoPub.h>)
+#import <MoPub/MoPub.h>
+#else
 #import "MPRewardedVideoCustomEvent.h"
+#endif
 
-/*
- * Please reference the Supported Mediation Partner page at http://bit.ly/2mqsuFH for the
- * latest version and ad format certifications.
- */
 @interface MPGoogleAdMobRewardedVideoCustomEvent : MPRewardedVideoCustomEvent
 
 @end


### PR DESCRIPTION
Added support for the usage of  use_frameworks! in Swift app
removed the following comments -
/*
 * Please reference the Supported Mediation Partner page at http://bit.ly/2mqsuFH for the
 * latest version and ad format certifications.
 */