### PR TITLE
Update FacebookRewardedVideoCustomEvent.m

### DIFF
--- a/FacebookAudienceNetwork/FacebookRewardedVideoCustomEvent.m
+++ b/FacebookAudienceNetwork/FacebookRewardedVideoCustomEvent.m
@@ -198,6 +198,12 @@
     [self.delegate rewardedVideoShouldRewardUserForCustomEvent:self reward:[[MPRewardedVideoReward alloc] initWithCurrencyAmount:@(kMPRewardedVideoRewardCurrencyAmountUnspecified)]];
 }
 
+//FBAudienceNetwork4.28 method name changed from rewardedVideoAdComplete to rewardedVideoAdComplete.
+//Fix bugs that won't receive rewards
+- (void)rewardedVideoAdVideoComplete:(FBRewardedVideoAd *)rewardedVideoAd{
+    [self rewardedVideoAdComplete:rewardedVideoAd];
+}
+
 /*!
  @method
  


### PR DESCRIPTION
FBAudienceNetwork4.28 FBRewardedVideoAdDelegate method name changed from rewardedVideoAdComplete to rewardedVideoAdComplete.Fix bugs that won't receive rewards