### PR TITLE
 Make AdColony adapter GDPR-compliant

### DIFF
--- a/AdColony/AdColonyController.m
+++ b/AdColony/AdColonyController.m
@@ -62,7 +62,7 @@ NSString *const kAdColonyConsentResponse = @"consent_response";
                 options.testMode = instance.testModeEnabled;
 
                 [options setOption:kAdColonyExplicitConsentGiven withNumericValue:@YES];
-                [options setOption:kAdColonyConsentResponse withNumericValue:MoPub.sharedInstance.canCollectPersonalInfo];
+                [options setOption:kAdColonyConsentResponse withNumericValue:@(MoPub.sharedInstance.canCollectPersonalInfo)];
 
                 [AdColony configureWithAppID:appId zoneIDs:allZoneIds options:options completion:^(NSArray<AdColonyZone *> * _Nonnull zones) {
                     @synchronized (instance) {
@@ -130,7 +130,7 @@ NSString *const kAdColonyConsentResponse = @"consent_response";
     BOOL canCollectPersonalInfo = [notification.userInfo[kMPConsentChangedInfoCanCollectPersonalInfoKey] boolValue];
     AdColonyAppOptions *options = [AdColony getAppOptions];
     [options setOption:kAdColonyExplicitConsentGiven withNumericValue:@YES];
-    [options setOption:kAdColonyConsentResponse withNumericValue:canCollectPersonalInfo];
+    [options setOption:kAdColonyConsentResponse withNumericValue:@(canCollectPersonalInfo)];
     [AdColony setAppOptions:options];
 }
 

--- a/AdColony/MoPub-AdColony-PodSpecs/MoPub-AdColony-Adapters.podspec
+++ b/AdColony/MoPub-AdColony-PodSpecs/MoPub-AdColony-Adapters.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'MoPub-AdColony-Adapters'
-  s.version          = '3.3.0.4'
+  s.version          = '3.3.4.0'
   s.summary          = 'AdColony Adapters for mediating through MoPub.'
   s.description      = <<-DESC
 Supported ad formats: Interstitial, Rewarded Video.\n
@@ -20,5 +20,5 @@ For inquiries and support, please email support@adcolony.com. \n
   s.static_framework = true
   s.source_files = 'AdColony/*.{h,m}'
   s.dependency 'mopub-ios-sdk', '~> 5.0'
-  s.dependency 'AdColony', '3.3.0'
+  s.dependency 'AdColony', '3.3.4'
 end


### PR DESCRIPTION
* Implement consent passing to AdColony ads
* Bump AdColony adapter version
* Box options