### PR TITLE
Update adapters for compatibility with MoPubSDKFramework

### DIFF
--- a/AdColony/AdColonyAdvancedBidder.h
+++ b/AdColony/AdColonyAdvancedBidder.h
@@ -7,9 +7,11 @@
 
 #import <Foundation/Foundation.h>
 #if __has_include(<MoPub/MoPub.h>)
-#import <MoPub/MoPub.h>
+    #import <MoPub/MoPub.h>
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MoPub.h>
 #else
-#import "MPAdvancedBidder.h"
+    #import "MPAdvancedBidder.h"
 #endif
 
 @interface AdColonyAdvancedBidder : NSObject<MPAdvancedBidder>

--- a/AdColony/AdColonyController.m
+++ b/AdColony/AdColonyController.m
@@ -9,8 +9,10 @@
 #import <AdColony/AdColony.h>
 #import "AdColonyController.h"
 #import "AdColonyGlobalMediationSettings.h"
-#import "MoPub.h"
-#import "MPRewardedVideo.h"
+#if __has_include("MoPub.h")
+    #import "MoPub.h"
+    #import "MPRewardedVideo.h"
+#endif
 
 typedef enum {
     INIT_STATE_UNKNOWN,

--- a/AdColony/AdColonyInterstitialCustomEvent.m
+++ b/AdColony/AdColonyInterstitialCustomEvent.m
@@ -7,7 +7,9 @@
 
 #import <AdColony/AdColony.h>
 #import "AdColonyInterstitialCustomEvent.h"
-#import "MPLogging.h"
+#if __has_include("MoPub.h")
+    #import "MPLogging.h"
+#endif
 #import "AdColonyController.h"
 
 @interface AdColonyInterstitialCustomEvent ()

--- a/AdColony/AdColonyRewardedVideoCustomEvent.m
+++ b/AdColony/AdColonyRewardedVideoCustomEvent.m
@@ -9,10 +9,12 @@
 #import "AdColonyRewardedVideoCustomEvent.h"
 #import "AdColonyInstanceMediationSettings.h"
 #import "AdColonyController.h"
-#import "MoPub.h"
-#import "MPLogging.h"
-#import "MPRewardedVideoReward.h"
-#import "MPRewardedVideoCustomEvent+Caching.h"
+#if __has_include("MoPub.h")
+    #import "MoPub.h"
+    #import "MPLogging.h"
+    #import "MPRewardedVideoReward.h"
+    #import "MPRewardedVideoCustomEvent+Caching.h"
+#endif
 
 #define ADCOLONY_INITIALIZATION_TIMEOUT dispatch_time(DISPATCH_TIME_NOW, 30 * NSEC_PER_SEC)
 

--- a/AdMob/MPGoogleAdMobBannerCustomEvent.m
+++ b/AdMob/MPGoogleAdMobBannerCustomEvent.m
@@ -7,7 +7,13 @@
 
 #import <GoogleMobileAds/GoogleMobileAds.h>
 #import "MPGoogleAdMobBannerCustomEvent.h"
-#import "MPLogging.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPLogging.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+// TODO: is this still needed after MPCoreInstanceProvider has been added to MoPubSDKFramework?
+    #import <CoreLocation/CLLocation.h>
+    #import <MoPubSDKFramework/MPLogging.h>
+#endif
 
 @interface MPGoogleAdMobBannerCustomEvent () <GADBannerViewDelegate>
 

--- a/AdMob/MPGoogleAdMobBannerCustomEvent.m
+++ b/AdMob/MPGoogleAdMobBannerCustomEvent.m
@@ -5,14 +5,12 @@
 //  Copyright (c) 2013 MoPub. All rights reserved.
 //
 
+#import <CoreLocation/CoreLocation.h>
+
 #import <GoogleMobileAds/GoogleMobileAds.h>
 #import "MPGoogleAdMobBannerCustomEvent.h"
-#if __has_include(<MoPub/MoPub.h>)
+#if __has_include("MoPub.h")
     #import "MPLogging.h"
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-// TODO: is this still needed after MPCoreInstanceProvider has been added to MoPubSDKFramework?
-    #import <CoreLocation/CLLocation.h>
-    #import <MoPubSDKFramework/MPLogging.h>
 #endif
 
 @interface MPGoogleAdMobBannerCustomEvent () <GADBannerViewDelegate>

--- a/AdMob/MPGoogleAdMobInterstitialCustomEvent.m
+++ b/AdMob/MPGoogleAdMobInterstitialCustomEvent.m
@@ -7,15 +7,10 @@
 
 #import <GoogleMobileAds/GoogleMobileAds.h>
 #import "MPGoogleAdMobInterstitialCustomEvent.h"
-#if __has_include(<MoPub/MoPub.h>)
+#if __has_include("MoPub.h")
     #import "MPInterstitialAdController.h"
     #import "MPLogging.h"
     #import "MPAdConfiguration.h"
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPInterstitialAdController.h>
-    #import <MoPubSDKFramework/MPLogging.h>
-// TODO: enable this import after MPAdConfiguration.h has been added to MoPubSDKFramework
-//    #import <MoPubSDKFramework/MPAdConfiguration.h>
 #endif
 #import <CoreLocation/CoreLocation.h>
 

--- a/AdMob/MPGoogleAdMobInterstitialCustomEvent.m
+++ b/AdMob/MPGoogleAdMobInterstitialCustomEvent.m
@@ -7,9 +7,16 @@
 
 #import <GoogleMobileAds/GoogleMobileAds.h>
 #import "MPGoogleAdMobInterstitialCustomEvent.h"
-#import "MPInterstitialAdController.h"
-#import "MPLogging.h"
-#import "MPAdConfiguration.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPInterstitialAdController.h"
+    #import "MPLogging.h"
+    #import "MPAdConfiguration.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPInterstitialAdController.h>
+    #import <MoPubSDKFramework/MPLogging.h>
+// TODO: enable this import after MPAdConfiguration.h has been added to MoPubSDKFramework
+//    #import <MoPubSDKFramework/MPAdConfiguration.h>
+#endif
 #import <CoreLocation/CoreLocation.h>
 
 @interface MPGoogleAdMobInterstitialCustomEvent () <GADInterstitialDelegate>

--- a/AdMob/MPGoogleAdMobNativeAdAdapter.m
+++ b/AdMob/MPGoogleAdMobNativeAdAdapter.m
@@ -1,9 +1,17 @@
 #import "MPGoogleAdMobNativeAdAdapter.h"
 
-#import "MPCoreInstanceProvider.h"
-#import "MPLogging.h"
-#import "MPNativeAdConstants.h"
-#import "MPNativeAdError.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPCoreInstanceProvider.h"
+    #import "MPLogging.h"
+    #import "MPNativeAdConstants.h"
+    #import "MPNativeAdError.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+// TODO: enable this import after MPCoreInstanceProvider has been added to MoPubSDKFramework
+//    #import <MoPubSDKFramework/MPCoreInstanceProvider.h>
+    #import <MoPubSDKFramework/MPLogging.h>
+    #import <MoPubSDKFramework/MPNativeAdConstants.h>
+    #import <MoPubSDKFramework/MPNativeAdError.h>
+#endif
 
 static NSString *const kGADMAdvertiserKey = @"advertiser";
 static NSString *const kGADMPriceKey = @"price";

--- a/AdMob/MPGoogleAdMobNativeAdAdapter.m
+++ b/AdMob/MPGoogleAdMobNativeAdAdapter.m
@@ -1,16 +1,10 @@
 #import "MPGoogleAdMobNativeAdAdapter.h"
 
-#if __has_include(<MoPub/MoPub.h>)
+#if __has_include("MoPub.h")
     #import "MPCoreInstanceProvider.h"
     #import "MPLogging.h"
     #import "MPNativeAdConstants.h"
     #import "MPNativeAdError.h"
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-// TODO: enable this import after MPCoreInstanceProvider has been added to MoPubSDKFramework
-//    #import <MoPubSDKFramework/MPCoreInstanceProvider.h>
-    #import <MoPubSDKFramework/MPLogging.h>
-    #import <MoPubSDKFramework/MPNativeAdConstants.h>
-    #import <MoPubSDKFramework/MPNativeAdError.h>
 #endif
 
 static NSString *const kGADMAdvertiserKey = @"advertiser";

--- a/AdMob/MPGoogleAdMobNativeCustomEvent.m
+++ b/AdMob/MPGoogleAdMobNativeCustomEvent.m
@@ -103,21 +103,21 @@ static GADAdChoicesPosition adChoicesPosition;
 
   NSMutableArray *imageURLs = [NSMutableArray array];
 
- if ([moPubNativeAd.properties[kAdIconImageKey] length]) {
-   if (![MPNativeAdUtils addURLString:moPubNativeAd.properties[kAdIconImageKey]
-                           toURLArray:imageURLs]) {
-     [self.delegate nativeCustomEvent:self
-             didFailToLoadAdWithError:MPNativeAdNSErrorForInvalidImageURL()];
-   }
- }
+  if ([moPubNativeAd.properties[kAdIconImageKey] length]) {
+    if (![MPNativeAdUtils addURLString:moPubNativeAd.properties[kAdIconImageKey]
+                            toURLArray:imageURLs]) {
+      [self.delegate nativeCustomEvent:self
+              didFailToLoadAdWithError:MPNativeAdNSErrorForInvalidImageURL()];
+    }
+  }
 
- if ([moPubNativeAd.properties[kAdMainImageKey] length]) {
-   if (![MPNativeAdUtils addURLString:moPubNativeAd.properties[kAdMainImageKey]
-                           toURLArray:imageURLs]) {
-     [self.delegate nativeCustomEvent:self
-             didFailToLoadAdWithError:MPNativeAdNSErrorForInvalidImageURL()];
-   }
- }
+  if ([moPubNativeAd.properties[kAdMainImageKey] length]) {
+    if (![MPNativeAdUtils addURLString:moPubNativeAd.properties[kAdMainImageKey]
+                            toURLArray:imageURLs]) {
+      [self.delegate nativeCustomEvent:self
+              didFailToLoadAdWithError:MPNativeAdNSErrorForInvalidImageURL()];
+    }
+  }
 
   [super precacheImagesWithURLs:imageURLs
                 completionBlock:^(NSArray *errors) {
@@ -148,21 +148,21 @@ static GADAdChoicesPosition adChoicesPosition;
 
   NSMutableArray *imageURLs = [NSMutableArray array];
 
- if ([interfaceAd.properties[kAdIconImageKey] length]) {
-   if (![MPNativeAdUtils addURLString:interfaceAd.properties[kAdIconImageKey]
-                           toURLArray:imageURLs]) {
-     [self.delegate nativeCustomEvent:self
-             didFailToLoadAdWithError:MPNativeAdNSErrorForInvalidImageURL()];
-   }
- }
+  if ([interfaceAd.properties[kAdIconImageKey] length]) {
+    if (![MPNativeAdUtils addURLString:interfaceAd.properties[kAdIconImageKey]
+                            toURLArray:imageURLs]) {
+      [self.delegate nativeCustomEvent:self
+              didFailToLoadAdWithError:MPNativeAdNSErrorForInvalidImageURL()];
+    }
+  }
 
- if ([interfaceAd.properties[kAdMainImageKey] length]) {
-   if (![MPNativeAdUtils addURLString:interfaceAd.properties[kAdMainImageKey]
-                           toURLArray:imageURLs]) {
-     [self.delegate nativeCustomEvent:self
-             didFailToLoadAdWithError:MPNativeAdNSErrorForInvalidImageURL()];
-   }
- }
+  if ([interfaceAd.properties[kAdMainImageKey] length]) {
+    if (![MPNativeAdUtils addURLString:interfaceAd.properties[kAdMainImageKey]
+                            toURLArray:imageURLs]) {
+      [self.delegate nativeCustomEvent:self
+              didFailToLoadAdWithError:MPNativeAdNSErrorForInvalidImageURL()];
+    }
+  }
 
   [super precacheImagesWithURLs:imageURLs
                 completionBlock:^(NSArray *errors) {

--- a/AdMob/MPGoogleAdMobNativeCustomEvent.m
+++ b/AdMob/MPGoogleAdMobNativeCustomEvent.m
@@ -1,10 +1,19 @@
 #import "MPGoogleAdMobNativeAdAdapter.h"
 #import "MPGoogleAdMobNativeCustomEvent.h"
-#import "MPLogging.h"
-#import "MPNativeAd.h"
-#import "MPNativeAdConstants.h"
-#import "MPNativeAdError.h"
-#import "MPNativeAdUtils.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPLogging.h"
+    #import "MPNativeAd.h"
+    #import "MPNativeAdConstants.h"
+    #import "MPNativeAdError.h"
+    #import "MPNativeAdUtils.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPLogging.h>
+    #import <MoPubSDKFramework/MPNativeAd.h>
+    #import <MoPubSDKFramework/MPNativeAdConstants.h>
+    #import <MoPubSDKFramework/MPNativeAdError.h>
+// TODO: enable this import (and disabled code below) after MPNativeAdUtils.h has been added to MoPubSDKFramework
+//    #import <MoPubSDKFramework/MPNativeAdUtils.h>
+#endif
 
 static void MPGoogleLogInfo(NSString *message) {
   message = [[NSString alloc] initWithFormat:@"<Google Adapter> - %@", message];
@@ -101,21 +110,21 @@ static GADAdChoicesPosition adChoicesPosition;
 
   NSMutableArray *imageURLs = [NSMutableArray array];
 
-  if ([moPubNativeAd.properties[kAdIconImageKey] length]) {
-    if (![MPNativeAdUtils addURLString:moPubNativeAd.properties[kAdIconImageKey]
-                            toURLArray:imageURLs]) {
-      [self.delegate nativeCustomEvent:self
-              didFailToLoadAdWithError:MPNativeAdNSErrorForInvalidImageURL()];
-    }
-  }
-
-  if ([moPubNativeAd.properties[kAdMainImageKey] length]) {
-    if (![MPNativeAdUtils addURLString:moPubNativeAd.properties[kAdMainImageKey]
-                            toURLArray:imageURLs]) {
-      [self.delegate nativeCustomEvent:self
-              didFailToLoadAdWithError:MPNativeAdNSErrorForInvalidImageURL()];
-    }
-  }
+//  if ([moPubNativeAd.properties[kAdIconImageKey] length]) {
+//    if (![MPNativeAdUtils addURLString:moPubNativeAd.properties[kAdIconImageKey]
+//                            toURLArray:imageURLs]) {
+//      [self.delegate nativeCustomEvent:self
+//              didFailToLoadAdWithError:MPNativeAdNSErrorForInvalidImageURL()];
+//    }
+//  }
+//
+//  if ([moPubNativeAd.properties[kAdMainImageKey] length]) {
+//    if (![MPNativeAdUtils addURLString:moPubNativeAd.properties[kAdMainImageKey]
+//                            toURLArray:imageURLs]) {
+//      [self.delegate nativeCustomEvent:self
+//              didFailToLoadAdWithError:MPNativeAdNSErrorForInvalidImageURL()];
+//    }
+//  }
 
   [super precacheImagesWithURLs:imageURLs
                 completionBlock:^(NSArray *errors) {
@@ -146,21 +155,21 @@ static GADAdChoicesPosition adChoicesPosition;
 
   NSMutableArray *imageURLs = [NSMutableArray array];
 
-  if ([interfaceAd.properties[kAdIconImageKey] length]) {
-    if (![MPNativeAdUtils addURLString:interfaceAd.properties[kAdIconImageKey]
-                            toURLArray:imageURLs]) {
-      [self.delegate nativeCustomEvent:self
-              didFailToLoadAdWithError:MPNativeAdNSErrorForInvalidImageURL()];
-    }
-  }
-
-  if ([interfaceAd.properties[kAdMainImageKey] length]) {
-    if (![MPNativeAdUtils addURLString:interfaceAd.properties[kAdMainImageKey]
-                            toURLArray:imageURLs]) {
-      [self.delegate nativeCustomEvent:self
-              didFailToLoadAdWithError:MPNativeAdNSErrorForInvalidImageURL()];
-    }
-  }
+//  if ([interfaceAd.properties[kAdIconImageKey] length]) {
+//    if (![MPNativeAdUtils addURLString:interfaceAd.properties[kAdIconImageKey]
+//                            toURLArray:imageURLs]) {
+//      [self.delegate nativeCustomEvent:self
+//              didFailToLoadAdWithError:MPNativeAdNSErrorForInvalidImageURL()];
+//    }
+//  }
+//
+//  if ([interfaceAd.properties[kAdMainImageKey] length]) {
+//    if (![MPNativeAdUtils addURLString:interfaceAd.properties[kAdMainImageKey]
+//                            toURLArray:imageURLs]) {
+//      [self.delegate nativeCustomEvent:self
+//              didFailToLoadAdWithError:MPNativeAdNSErrorForInvalidImageURL()];
+//    }
+//  }
 
   [super precacheImagesWithURLs:imageURLs
                 completionBlock:^(NSArray *errors) {

--- a/AdMob/MPGoogleAdMobNativeCustomEvent.m
+++ b/AdMob/MPGoogleAdMobNativeCustomEvent.m
@@ -1,18 +1,11 @@
 #import "MPGoogleAdMobNativeAdAdapter.h"
 #import "MPGoogleAdMobNativeCustomEvent.h"
-#if __has_include(<MoPub/MoPub.h>)
+#if __has_include("MoPub.h")
     #import "MPLogging.h"
     #import "MPNativeAd.h"
     #import "MPNativeAdConstants.h"
     #import "MPNativeAdError.h"
     #import "MPNativeAdUtils.h"
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPLogging.h>
-    #import <MoPubSDKFramework/MPNativeAd.h>
-    #import <MoPubSDKFramework/MPNativeAdConstants.h>
-    #import <MoPubSDKFramework/MPNativeAdError.h>
-// TODO: enable this import (and disabled code below) after MPNativeAdUtils.h has been added to MoPubSDKFramework
-//    #import <MoPubSDKFramework/MPNativeAdUtils.h>
 #endif
 
 static void MPGoogleLogInfo(NSString *message) {

--- a/AdMob/MPGoogleAdMobNativeCustomEvent.m
+++ b/AdMob/MPGoogleAdMobNativeCustomEvent.m
@@ -103,21 +103,21 @@ static GADAdChoicesPosition adChoicesPosition;
 
   NSMutableArray *imageURLs = [NSMutableArray array];
 
-//  if ([moPubNativeAd.properties[kAdIconImageKey] length]) {
-//    if (![MPNativeAdUtils addURLString:moPubNativeAd.properties[kAdIconImageKey]
-//                            toURLArray:imageURLs]) {
-//      [self.delegate nativeCustomEvent:self
-//              didFailToLoadAdWithError:MPNativeAdNSErrorForInvalidImageURL()];
-//    }
-//  }
-//
-//  if ([moPubNativeAd.properties[kAdMainImageKey] length]) {
-//    if (![MPNativeAdUtils addURLString:moPubNativeAd.properties[kAdMainImageKey]
-//                            toURLArray:imageURLs]) {
-//      [self.delegate nativeCustomEvent:self
-//              didFailToLoadAdWithError:MPNativeAdNSErrorForInvalidImageURL()];
-//    }
-//  }
+ if ([moPubNativeAd.properties[kAdIconImageKey] length]) {
+   if (![MPNativeAdUtils addURLString:moPubNativeAd.properties[kAdIconImageKey]
+                           toURLArray:imageURLs]) {
+     [self.delegate nativeCustomEvent:self
+             didFailToLoadAdWithError:MPNativeAdNSErrorForInvalidImageURL()];
+   }
+ }
+
+ if ([moPubNativeAd.properties[kAdMainImageKey] length]) {
+   if (![MPNativeAdUtils addURLString:moPubNativeAd.properties[kAdMainImageKey]
+                           toURLArray:imageURLs]) {
+     [self.delegate nativeCustomEvent:self
+             didFailToLoadAdWithError:MPNativeAdNSErrorForInvalidImageURL()];
+   }
+ }
 
   [super precacheImagesWithURLs:imageURLs
                 completionBlock:^(NSArray *errors) {
@@ -148,21 +148,21 @@ static GADAdChoicesPosition adChoicesPosition;
 
   NSMutableArray *imageURLs = [NSMutableArray array];
 
-//  if ([interfaceAd.properties[kAdIconImageKey] length]) {
-//    if (![MPNativeAdUtils addURLString:interfaceAd.properties[kAdIconImageKey]
-//                            toURLArray:imageURLs]) {
-//      [self.delegate nativeCustomEvent:self
-//              didFailToLoadAdWithError:MPNativeAdNSErrorForInvalidImageURL()];
-//    }
-//  }
-//
-//  if ([interfaceAd.properties[kAdMainImageKey] length]) {
-//    if (![MPNativeAdUtils addURLString:interfaceAd.properties[kAdMainImageKey]
-//                            toURLArray:imageURLs]) {
-//      [self.delegate nativeCustomEvent:self
-//              didFailToLoadAdWithError:MPNativeAdNSErrorForInvalidImageURL()];
-//    }
-//  }
+ if ([interfaceAd.properties[kAdIconImageKey] length]) {
+   if (![MPNativeAdUtils addURLString:interfaceAd.properties[kAdIconImageKey]
+                           toURLArray:imageURLs]) {
+     [self.delegate nativeCustomEvent:self
+             didFailToLoadAdWithError:MPNativeAdNSErrorForInvalidImageURL()];
+   }
+ }
+
+ if ([interfaceAd.properties[kAdMainImageKey] length]) {
+   if (![MPNativeAdUtils addURLString:interfaceAd.properties[kAdMainImageKey]
+                           toURLArray:imageURLs]) {
+     [self.delegate nativeCustomEvent:self
+             didFailToLoadAdWithError:MPNativeAdNSErrorForInvalidImageURL()];
+   }
+ }
 
   [super precacheImagesWithURLs:imageURLs
                 completionBlock:^(NSArray *errors) {

--- a/AdMob/MPGoogleAdMobNativeRenderer.m
+++ b/AdMob/MPGoogleAdMobNativeRenderer.m
@@ -17,296 +17,296 @@
 #import "MPGoogleAdMobNativeAdAdapter.h"
 #import "UIView+MPGoogleAdMobAdditions.h"
 
-//@interface MPGoogleAdMobNativeRenderer ()<MPNativeAdRendererImageHandlerDelegate>
-//
-///// Publisher adView which is rendering.
-//@property(nonatomic, strong) UIView<MPNativeAdRendering> *adView;
-//
-///// MPGoogleAdMobNativeAdAdapter instance.
-//@property(nonatomic, strong) MPGoogleAdMobNativeAdAdapter *adapter;
-//
-///// YES if adView is in view hierarchy.
-//@property(nonatomic, assign) BOOL adViewInViewHierarchy;
-//
-///// MPNativeAdRendererImageHandler instance.
-//@property(nonatomic, strong) MPNativeAdRendererImageHandler *rendererImageHandler;
-//
-///// Class of renderingViewClass.
-//@property(nonatomic, strong) Class renderingViewClass;
-//
-///// GADNativeAppInstallAdView instance.
-//@property(nonatomic, strong) GADNativeAppInstallAdView *appInstallAdView;
-//
-//@end
-//
-//@implementation MPGoogleAdMobNativeRenderer
-//
-//@synthesize viewSizeHandler;
-//
-///// Construct and return an MPNativeAdRendererConfiguration object, you must set all the properties
-///// on the configuration object.
-//+ (MPNativeAdRendererConfiguration *)rendererConfigurationWithRendererSettings:
-//(id<MPNativeAdRendererSettings>)rendererSettings {
-//    MPNativeAdRendererConfiguration *config = [[MPNativeAdRendererConfiguration alloc] init];
-//    config.rendererClass = [self class];
-//    config.rendererSettings = rendererSettings;
-//    config.supportedCustomEvents = @[ @"MPGoogleAdMobNativeCustomEvent" ];
-//
-//    return config;
-//}
-//
-///// Renderer settings are objects that allow you to expose configurable properties to the
-///// application. MPGoogleAdMobNativeRenderer renderer will be initialized with these settings.
-//- (instancetype)initWithRendererSettings:(id<MPNativeAdRendererSettings>)rendererSettings {
-//    if (self = [super init]) {
-//        MPStaticNativeAdRendererSettings *settings =
-//        (MPStaticNativeAdRendererSettings *)rendererSettings;
-//        _renderingViewClass = settings.renderingViewClass;
-//        viewSizeHandler = [settings.viewSizeHandler copy];
-//        _rendererImageHandler = [MPNativeAdRendererImageHandler new];
-//        _rendererImageHandler.delegate = self;
-//    }
-//
-//    return self;
-//}
-//
-///// Returns an ad view rendered using provided |adapter|. Sets an |error| if any error is
-///// encountered.
-//- (UIView *)retrieveViewWithAdapter:(id<MPNativeAdAdapter>)adapter error:(NSError **)error {
-//    if (!adapter || ![adapter isKindOfClass:[MPGoogleAdMobNativeAdAdapter class]]) {
-//        if (error) {
-//            *error = MPNativeAdNSErrorForRenderValueTypeError();
-//        }
-//
-//        return nil;
-//    }
-//
-//    self.adapter = (MPGoogleAdMobNativeAdAdapter *)adapter;
-//
-//    if ([self.renderingViewClass respondsToSelector:@selector(nibForAd)]) {
-//        self.adView = (UIView<MPNativeAdRendering> *)[
-//                                                      [[self.renderingViewClass nibForAd] instantiateWithOwner:nil options:nil] firstObject];
-//    } else {
-//        self.adView = [[self.renderingViewClass alloc] init];
-//    }
-//
-//    self.adView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-//
-//    if (self.adapter.adMobNativeAppInstallAd) {
-//        [self renderAppInstallAdViewWithAdapter:self.adapter];
-//    } else {
-//        [self renderContentAdViewWithAdapter:self.adapter];
-//    }
-//
-//    return self.adView;
-//}
-//
-///// Creates native app install ad view with adapter. We added GADNativeAppInstallAdView assets on
-///// top of MoPub's adView, to track impressions & clicks.
-//- (void)renderAppInstallAdViewWithAdapter:(id<MPNativeAdAdapter>)adapter {
-//    // We only load text here. We're creating the GADNativeAppInstallAdView and preparing text
-//    // assets.
-//    GADNativeAppInstallAdView *gadAppInstallAdView = [[GADNativeAppInstallAdView alloc] init];
-//    [self.adView addSubview:gadAppInstallAdView];
-//    [gadAppInstallAdView gad_fillSuperview];
-//
-//    gadAppInstallAdView.adChoicesView = (GADAdChoicesView *)[self.adapter privacyInformationIconView];
-//    gadAppInstallAdView.nativeAppInstallAd = self.adapter.adMobNativeAppInstallAd;
-//    if ([self.adView respondsToSelector:@selector(nativeTitleTextLabel)]) {
-//        UILabel *headlineView = [[UILabel alloc] initWithFrame:CGRectZero];
-//        headlineView.text = self.adapter.adMobNativeAppInstallAd.headline;
-//        headlineView.textColor = [UIColor clearColor];
-//        gadAppInstallAdView.headlineView = headlineView;
-//        [self.adView.nativeTitleTextLabel addSubview:headlineView];
-//        [headlineView gad_fillSuperview];
-//        self.adView.nativeTitleTextLabel.text = adapter.properties[kAdTitleKey];
-//    }
-//
-//    if ([self.adView respondsToSelector:@selector(nativeMainTextLabel)]) {
-//        UILabel *bodyView = [[UILabel alloc] initWithFrame:CGRectZero];
-//        bodyView.text = self.adapter.adMobNativeAppInstallAd.body;
-//        bodyView.textColor = [UIColor clearColor];
-//        gadAppInstallAdView.bodyView = bodyView;
-//        [self.adView.nativeMainTextLabel addSubview:bodyView];
-//        [bodyView gad_fillSuperview];
-//        self.adView.nativeMainTextLabel.text = adapter.properties[kAdTextKey];
-//    }
-//
-//    if ([self.adView respondsToSelector:@selector(nativeCallToActionTextLabel)] &&
-//        self.adView.nativeCallToActionTextLabel) {
-//        UILabel *callToActionView = [[UILabel alloc] initWithFrame:CGRectZero];
-//        callToActionView.text = self.adapter.adMobNativeAppInstallAd.callToAction;
-//        callToActionView.textColor = [UIColor clearColor];
-//        gadAppInstallAdView.callToActionView = callToActionView;
-//        [self.adView.nativeCallToActionTextLabel addSubview:callToActionView];
-//        [callToActionView gad_fillSuperview];
-//        self.adView.nativeCallToActionTextLabel.text = adapter.properties[kAdCTATextKey];
-//    }
-//
-//    // We delay loading of images until the view is added to the view hierarchy so we don't
-//    // unnecessarily load images from the cache if the user is scrolling fast. So we will just store
-//    // the image URLs for now.
-//    if ([self.adView respondsToSelector:@selector(nativeMainImageView)]) {
-//        NSString *mainImageURLString = adapter.properties[kAdMainImageKey];
-//        GADNativeAdImage *nativeAdImage =
-//        [[GADNativeAdImage alloc] initWithURL:[NSURL URLWithString:mainImageURLString] scale:1];
-//        UIImageView *mainMediaImageView = [[UIImageView alloc] initWithFrame:CGRectZero];
-//        mainMediaImageView.image = nativeAdImage.image;
-//        gadAppInstallAdView.imageView = mainMediaImageView;
-//        [self.adView.nativeMainImageView addSubview:mainMediaImageView];
-//        [mainMediaImageView gad_fillSuperview];
-//    }
-//
-//    if ([self.adView respondsToSelector:@selector(nativeIconImageView)]) {
-//        NSString *iconImageURLString = adapter.properties[kAdIconImageKey];
-//        GADNativeAdImage *nativeAdImage =
-//        [[GADNativeAdImage alloc] initWithURL:[NSURL URLWithString:iconImageURLString] scale:1];
-//        UIImageView *iconView = [[UIImageView alloc] initWithFrame:CGRectZero];
-//        iconView.image = nativeAdImage.image;
-//        gadAppInstallAdView.iconView = iconView;
-//        [self.adView.nativeIconImageView addSubview:iconView];
-//        [iconView gad_fillSuperview];
-//    }
-//
-//    // See if the ad contains a star rating and notify the view if it does.
-//    if ([self.adView respondsToSelector:@selector(layoutStarRating:)]) {
-//        NSNumber *starRatingNum = adapter.properties[kAdStarRatingKey];
-//        if ([starRatingNum isKindOfClass:[NSNumber class]] &&
-//            starRatingNum.floatValue >= kStarRatingMinValue &&
-//            starRatingNum.floatValue <= kStarRatingMaxValue) {
-//            [self.adView layoutStarRating:starRatingNum];
-//        }
-//    }
-//
-//    // See if the ad contains the nativePrivacyInformationIconImageView and add GADAdChoices view
-//    // as its subview if it does.
-//    if ([self.adView respondsToSelector:@selector(nativePrivacyInformationIconImageView)]) {
-//        [self.adView.nativePrivacyInformationIconImageView
-//         addSubview:gadAppInstallAdView.adChoicesView];
-//    }
-//}
-//
-///// Creates native app content ad view with adapter. We added GADNativeContentAdView assets on top
-///// of MoPub's adView, to track impressions & clicks.
-//- (void)renderContentAdViewWithAdapter:(id<MPNativeAdAdapter>)adapter {
-//    // We only load text here. We're creating the GADNativeContentAdView and preparing text assets.
-//    GADNativeContentAdView *gadAppContentAdView = [[GADNativeContentAdView alloc] init];
-//    [self.adView addSubview:gadAppContentAdView];
-//    [gadAppContentAdView gad_fillSuperview];
-//
-//    gadAppContentAdView.adChoicesView = (GADAdChoicesView *)[self.adapter privacyInformationIconView];
-//    gadAppContentAdView.nativeContentAd = self.adapter.adMobNativeContentAd;
-//    if ([self.adView respondsToSelector:@selector(nativeTitleTextLabel)]) {
-//        UILabel *headlineView = [[UILabel alloc] initWithFrame:CGRectZero];
-//        headlineView.text = self.adapter.adMobNativeContentAd.headline;
-//        headlineView.textColor = [UIColor clearColor];
-//        gadAppContentAdView.headlineView = headlineView;
-//        [self.adView.nativeTitleTextLabel addSubview:headlineView];
-//        [headlineView gad_fillSuperview];
-//        self.adView.nativeTitleTextLabel.text = adapter.properties[kAdTitleKey];
-//    }
-//
-//    if ([self.adView respondsToSelector:@selector(nativeMainTextLabel)]) {
-//        UILabel *bodyView = [[UILabel alloc] initWithFrame:CGRectZero];
-//        bodyView.text = self.adapter.adMobNativeContentAd.body;
-//        bodyView.textColor = [UIColor clearColor];
-//        gadAppContentAdView.bodyView = bodyView;
-//        [self.adView.nativeMainTextLabel addSubview:bodyView];
-//        [bodyView gad_fillSuperview];
-//        self.adView.nativeMainTextLabel.text = adapter.properties[kAdTextKey];
-//    }
-//
-//    if ([self.adView respondsToSelector:@selector(nativeCallToActionTextLabel)] &&
-//        self.adView.nativeCallToActionTextLabel) {
-//        UILabel *callToActionView = [[UILabel alloc] initWithFrame:CGRectZero];
-//        callToActionView.text = self.adapter.adMobNativeContentAd.callToAction;
-//        callToActionView.textColor = [UIColor clearColor];
-//        gadAppContentAdView.callToActionView = callToActionView;
-//        [self.adView.nativeCallToActionTextLabel addSubview:callToActionView];
-//        [callToActionView gad_fillSuperview];
-//        self.adView.nativeCallToActionTextLabel.text = adapter.properties[kAdCTATextKey];
-//    }
-//
-//    // We delay loading of images until the view is added to the view hierarchy so we don't
-//    // unnecessarily load images from the cache if the user is scrolling fast. So we will just store
-//    // the image URLs for now.
-//    if ([self.adView respondsToSelector:@selector(nativeMainImageView)]) {
-//        NSString *mainImageURLString = adapter.properties[kAdMainImageKey];
-//        GADNativeAdImage *nativeAdImage =
-//        [[GADNativeAdImage alloc] initWithURL:[NSURL URLWithString:mainImageURLString] scale:1];
-//        UIImageView *mainMediaImageView = [[UIImageView alloc] initWithFrame:CGRectZero];
-//        mainMediaImageView.image = nativeAdImage.image;
-//        gadAppContentAdView.imageView = mainMediaImageView;
-//        [self.adView.nativeMainImageView addSubview:mainMediaImageView];
-//        [mainMediaImageView gad_fillSuperview];
-//    }
-//
-//    if ([self.adView respondsToSelector:@selector(nativeIconImageView)]) {
-//        NSString *iconImageURLString = adapter.properties[kAdIconImageKey];
-//        GADNativeAdImage *nativeAdImage =
-//        [[GADNativeAdImage alloc] initWithURL:[NSURL URLWithString:iconImageURLString] scale:1];
-//        UIImageView *iconView = [[UIImageView alloc] initWithFrame:CGRectZero];
-//        iconView.image = nativeAdImage.image;
-//        gadAppContentAdView.logoView = iconView;
-//        [self.adView.nativeIconImageView addSubview:iconView];
-//        [iconView gad_fillSuperview];
-//    }
-//
-//    // See if the ad contains the nativePrivacyInformationIconImageView and add GADAdChoices view
-//    // as its subview if it does.
-//    if ([self.adView respondsToSelector:@selector(nativePrivacyInformationIconImageView)]) {
-//        [self.adView.nativePrivacyInformationIconImageView
-//         addSubview:gadAppContentAdView.adChoicesView];
-//    }
-//}
-//
-///// Checks whether the ad view contains media.
-//- (BOOL)shouldLoadMediaView {
-//    return [self.adapter respondsToSelector:@selector(mainMediaView)] &&
-//    [self.adapter mainMediaView] &&
-//    [self.adView respondsToSelector:@selector(nativeMainImageView)];
-//}
-//
-///// Check the ad view is superView or not, if not adView will move to superView.
-//- (void)adViewWillMoveToSuperview:(UIView *)superview {
-//    self.adViewInViewHierarchy = (superview != nil);
-//
-//    if (superview) {
-//        // We'll start asychronously loading the native ad images now.
-//        if (self.adapter.properties[kAdIconImageKey] &&
-//            [self.adView respondsToSelector:@selector(nativeIconImageView)]) {
-//            [self.rendererImageHandler
-//             loadImageForURL:[NSURL URLWithString:self.adapter.properties[kAdIconImageKey]]
-//             intoImageView:self.adView.nativeIconImageView];
-//        }
-//
-//        // Only handle the loading of the main image if the adapter doesn't already have a view for it.
-//        if (!([self.adapter respondsToSelector:@selector(mainMediaView)] &&
-//              [self.adapter mainMediaView])) {
-//            if (self.adapter.properties[kAdMainImageKey] &&
-//                [self.adView respondsToSelector:@selector(nativeMainImageView)]) {
-//                [self.rendererImageHandler
-//                 loadImageForURL:[NSURL URLWithString:self.adapter.properties[kAdMainImageKey]]
-//                 intoImageView:self.adView.nativeMainImageView];
-//            }
-//        }
-//
-//        // Lay out custom assets here as the custom assets may contain images that need to be loaded.
-//        if ([self.adView respondsToSelector:@selector(layoutCustomAssetsWithProperties:imageLoader:)]) {
-//            // Create a simplified image loader for the ad view to use.
-//            MPNativeAdRenderingImageLoader *imageLoader =
-//            [[MPNativeAdRenderingImageLoader alloc] initWithImageHandler:self.rendererImageHandler];
-//            [self.adView layoutCustomAssetsWithProperties:self.adapter.properties
-//                                              imageLoader:imageLoader];
-//        }
-//    }
-//}
-//
-//#pragma mark - MPNativeAdRendererImageHandlerDelegate
-//
-//- (BOOL)nativeAdViewInViewHierarchy {
-//    return self.adViewInViewHierarchy;
-//}
-//
-//@end
+@interface MPGoogleAdMobNativeRenderer () //<MPNativeAdRendererImageHandlerDelegate>
+
+/// Publisher adView which is rendering.
+@property(nonatomic, strong) UIView<MPNativeAdRendering> *adView;
+
+/// MPGoogleAdMobNativeAdAdapter instance.
+@property(nonatomic, strong) MPGoogleAdMobNativeAdAdapter *adapter;
+
+/// YES if adView is in view hierarchy.
+@property(nonatomic, assign) BOOL adViewInViewHierarchy;
+
+/// MPNativeAdRendererImageHandler instance.
+@property(nonatomic, strong) MPNativeAdRendererImageHandler *rendererImageHandler;
+
+/// Class of renderingViewClass.
+@property(nonatomic, strong) Class renderingViewClass;
+
+/// GADNativeAppInstallAdView instance.
+@property(nonatomic, strong) GADNativeAppInstallAdView *appInstallAdView;
+
+@end
+
+@implementation MPGoogleAdMobNativeRenderer
+
+@synthesize viewSizeHandler;
+
+/// Construct and return an MPNativeAdRendererConfiguration object, you must set all the properties
+/// on the configuration object.
++ (MPNativeAdRendererConfiguration *)rendererConfigurationWithRendererSettings:
+(id<MPNativeAdRendererSettings>)rendererSettings {
+    MPNativeAdRendererConfiguration *config = [[MPNativeAdRendererConfiguration alloc] init];
+    config.rendererClass = [self class];
+    config.rendererSettings = rendererSettings;
+    config.supportedCustomEvents = @[ @"MPGoogleAdMobNativeCustomEvent" ];
+
+    return config;
+}
+
+/// Renderer settings are objects that allow you to expose configurable properties to the
+/// application. MPGoogleAdMobNativeRenderer renderer will be initialized with these settings.
+- (instancetype)initWithRendererSettings:(id<MPNativeAdRendererSettings>)rendererSettings {
+    if (self = [super init]) {
+        MPStaticNativeAdRendererSettings *settings =
+        (MPStaticNativeAdRendererSettings *)rendererSettings;
+        _renderingViewClass = settings.renderingViewClass;
+        viewSizeHandler = [settings.viewSizeHandler copy];
+        _rendererImageHandler = nil; //[MPNativeAdRendererImageHandler new];
+        //_rendererImageHandler.delegate = self;
+    }
+
+    return self;
+}
+
+/// Returns an ad view rendered using provided |adapter|. Sets an |error| if any error is
+/// encountered.
+- (UIView *)retrieveViewWithAdapter:(id<MPNativeAdAdapter>)adapter error:(NSError **)error {
+    if (!adapter || ![adapter isKindOfClass:[MPGoogleAdMobNativeAdAdapter class]]) {
+        if (error) {
+            *error = MPNativeAdNSErrorForRenderValueTypeError();
+        }
+
+        return nil;
+    }
+
+    self.adapter = (MPGoogleAdMobNativeAdAdapter *)adapter;
+
+    if ([self.renderingViewClass respondsToSelector:@selector(nibForAd)]) {
+        self.adView = (UIView<MPNativeAdRendering> *)[
+                                                      [[self.renderingViewClass nibForAd] instantiateWithOwner:nil options:nil] firstObject];
+    } else {
+        self.adView = [[self.renderingViewClass alloc] init];
+    }
+
+    self.adView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+
+    if (self.adapter.adMobNativeAppInstallAd) {
+        [self renderAppInstallAdViewWithAdapter:self.adapter];
+    } else {
+        [self renderContentAdViewWithAdapter:self.adapter];
+    }
+
+    return self.adView;
+}
+
+/// Creates native app install ad view with adapter. We added GADNativeAppInstallAdView assets on
+/// top of MoPub's adView, to track impressions & clicks.
+- (void)renderAppInstallAdViewWithAdapter:(id<MPNativeAdAdapter>)adapter {
+    // We only load text here. We're creating the GADNativeAppInstallAdView and preparing text
+    // assets.
+    GADNativeAppInstallAdView *gadAppInstallAdView = [[GADNativeAppInstallAdView alloc] init];
+    [self.adView addSubview:gadAppInstallAdView];
+    [gadAppInstallAdView gad_fillSuperview];
+
+    gadAppInstallAdView.adChoicesView = (GADAdChoicesView *)[self.adapter privacyInformationIconView];
+    gadAppInstallAdView.nativeAppInstallAd = self.adapter.adMobNativeAppInstallAd;
+    if ([self.adView respondsToSelector:@selector(nativeTitleTextLabel)]) {
+        UILabel *headlineView = [[UILabel alloc] initWithFrame:CGRectZero];
+        headlineView.text = self.adapter.adMobNativeAppInstallAd.headline;
+        headlineView.textColor = [UIColor clearColor];
+        gadAppInstallAdView.headlineView = headlineView;
+        [self.adView.nativeTitleTextLabel addSubview:headlineView];
+        [headlineView gad_fillSuperview];
+        self.adView.nativeTitleTextLabel.text = adapter.properties[kAdTitleKey];
+    }
+
+    if ([self.adView respondsToSelector:@selector(nativeMainTextLabel)]) {
+        UILabel *bodyView = [[UILabel alloc] initWithFrame:CGRectZero];
+        bodyView.text = self.adapter.adMobNativeAppInstallAd.body;
+        bodyView.textColor = [UIColor clearColor];
+        gadAppInstallAdView.bodyView = bodyView;
+        [self.adView.nativeMainTextLabel addSubview:bodyView];
+        [bodyView gad_fillSuperview];
+        self.adView.nativeMainTextLabel.text = adapter.properties[kAdTextKey];
+    }
+
+    if ([self.adView respondsToSelector:@selector(nativeCallToActionTextLabel)] &&
+        self.adView.nativeCallToActionTextLabel) {
+        UILabel *callToActionView = [[UILabel alloc] initWithFrame:CGRectZero];
+        callToActionView.text = self.adapter.adMobNativeAppInstallAd.callToAction;
+        callToActionView.textColor = [UIColor clearColor];
+        gadAppInstallAdView.callToActionView = callToActionView;
+        [self.adView.nativeCallToActionTextLabel addSubview:callToActionView];
+        [callToActionView gad_fillSuperview];
+        self.adView.nativeCallToActionTextLabel.text = adapter.properties[kAdCTATextKey];
+    }
+
+    // We delay loading of images until the view is added to the view hierarchy so we don't
+    // unnecessarily load images from the cache if the user is scrolling fast. So we will just store
+    // the image URLs for now.
+    if ([self.adView respondsToSelector:@selector(nativeMainImageView)]) {
+        NSString *mainImageURLString = adapter.properties[kAdMainImageKey];
+        GADNativeAdImage *nativeAdImage =
+        [[GADNativeAdImage alloc] initWithURL:[NSURL URLWithString:mainImageURLString] scale:1];
+        UIImageView *mainMediaImageView = [[UIImageView alloc] initWithFrame:CGRectZero];
+        mainMediaImageView.image = nativeAdImage.image;
+        gadAppInstallAdView.imageView = mainMediaImageView;
+        [self.adView.nativeMainImageView addSubview:mainMediaImageView];
+        [mainMediaImageView gad_fillSuperview];
+    }
+
+    if ([self.adView respondsToSelector:@selector(nativeIconImageView)]) {
+        NSString *iconImageURLString = adapter.properties[kAdIconImageKey];
+        GADNativeAdImage *nativeAdImage =
+        [[GADNativeAdImage alloc] initWithURL:[NSURL URLWithString:iconImageURLString] scale:1];
+        UIImageView *iconView = [[UIImageView alloc] initWithFrame:CGRectZero];
+        iconView.image = nativeAdImage.image;
+        gadAppInstallAdView.iconView = iconView;
+        [self.adView.nativeIconImageView addSubview:iconView];
+        [iconView gad_fillSuperview];
+    }
+
+    // See if the ad contains a star rating and notify the view if it does.
+    if ([self.adView respondsToSelector:@selector(layoutStarRating:)]) {
+        NSNumber *starRatingNum = adapter.properties[kAdStarRatingKey];
+        if ([starRatingNum isKindOfClass:[NSNumber class]] &&
+            starRatingNum.floatValue >= kStarRatingMinValue &&
+            starRatingNum.floatValue <= kStarRatingMaxValue) {
+            [self.adView layoutStarRating:starRatingNum];
+        }
+    }
+
+    // See if the ad contains the nativePrivacyInformationIconImageView and add GADAdChoices view
+    // as its subview if it does.
+    if ([self.adView respondsToSelector:@selector(nativePrivacyInformationIconImageView)]) {
+        [self.adView.nativePrivacyInformationIconImageView
+         addSubview:gadAppInstallAdView.adChoicesView];
+    }
+}
+
+/// Creates native app content ad view with adapter. We added GADNativeContentAdView assets on top
+/// of MoPub's adView, to track impressions & clicks.
+- (void)renderContentAdViewWithAdapter:(id<MPNativeAdAdapter>)adapter {
+    // We only load text here. We're creating the GADNativeContentAdView and preparing text assets.
+    GADNativeContentAdView *gadAppContentAdView = [[GADNativeContentAdView alloc] init];
+    [self.adView addSubview:gadAppContentAdView];
+    [gadAppContentAdView gad_fillSuperview];
+
+    gadAppContentAdView.adChoicesView = (GADAdChoicesView *)[self.adapter privacyInformationIconView];
+    gadAppContentAdView.nativeContentAd = self.adapter.adMobNativeContentAd;
+    if ([self.adView respondsToSelector:@selector(nativeTitleTextLabel)]) {
+        UILabel *headlineView = [[UILabel alloc] initWithFrame:CGRectZero];
+        headlineView.text = self.adapter.adMobNativeContentAd.headline;
+        headlineView.textColor = [UIColor clearColor];
+        gadAppContentAdView.headlineView = headlineView;
+        [self.adView.nativeTitleTextLabel addSubview:headlineView];
+        [headlineView gad_fillSuperview];
+        self.adView.nativeTitleTextLabel.text = adapter.properties[kAdTitleKey];
+    }
+
+    if ([self.adView respondsToSelector:@selector(nativeMainTextLabel)]) {
+        UILabel *bodyView = [[UILabel alloc] initWithFrame:CGRectZero];
+        bodyView.text = self.adapter.adMobNativeContentAd.body;
+        bodyView.textColor = [UIColor clearColor];
+        gadAppContentAdView.bodyView = bodyView;
+        [self.adView.nativeMainTextLabel addSubview:bodyView];
+        [bodyView gad_fillSuperview];
+        self.adView.nativeMainTextLabel.text = adapter.properties[kAdTextKey];
+    }
+
+    if ([self.adView respondsToSelector:@selector(nativeCallToActionTextLabel)] &&
+        self.adView.nativeCallToActionTextLabel) {
+        UILabel *callToActionView = [[UILabel alloc] initWithFrame:CGRectZero];
+        callToActionView.text = self.adapter.adMobNativeContentAd.callToAction;
+        callToActionView.textColor = [UIColor clearColor];
+        gadAppContentAdView.callToActionView = callToActionView;
+        [self.adView.nativeCallToActionTextLabel addSubview:callToActionView];
+        [callToActionView gad_fillSuperview];
+        self.adView.nativeCallToActionTextLabel.text = adapter.properties[kAdCTATextKey];
+    }
+
+    // We delay loading of images until the view is added to the view hierarchy so we don't
+    // unnecessarily load images from the cache if the user is scrolling fast. So we will just store
+    // the image URLs for now.
+    if ([self.adView respondsToSelector:@selector(nativeMainImageView)]) {
+        NSString *mainImageURLString = adapter.properties[kAdMainImageKey];
+        GADNativeAdImage *nativeAdImage =
+        [[GADNativeAdImage alloc] initWithURL:[NSURL URLWithString:mainImageURLString] scale:1];
+        UIImageView *mainMediaImageView = [[UIImageView alloc] initWithFrame:CGRectZero];
+        mainMediaImageView.image = nativeAdImage.image;
+        gadAppContentAdView.imageView = mainMediaImageView;
+        [self.adView.nativeMainImageView addSubview:mainMediaImageView];
+        [mainMediaImageView gad_fillSuperview];
+    }
+
+    if ([self.adView respondsToSelector:@selector(nativeIconImageView)]) {
+        NSString *iconImageURLString = adapter.properties[kAdIconImageKey];
+        GADNativeAdImage *nativeAdImage =
+        [[GADNativeAdImage alloc] initWithURL:[NSURL URLWithString:iconImageURLString] scale:1];
+        UIImageView *iconView = [[UIImageView alloc] initWithFrame:CGRectZero];
+        iconView.image = nativeAdImage.image;
+        gadAppContentAdView.logoView = iconView;
+        [self.adView.nativeIconImageView addSubview:iconView];
+        [iconView gad_fillSuperview];
+    }
+
+    // See if the ad contains the nativePrivacyInformationIconImageView and add GADAdChoices view
+    // as its subview if it does.
+    if ([self.adView respondsToSelector:@selector(nativePrivacyInformationIconImageView)]) {
+        [self.adView.nativePrivacyInformationIconImageView
+         addSubview:gadAppContentAdView.adChoicesView];
+    }
+}
+
+/// Checks whether the ad view contains media.
+- (BOOL)shouldLoadMediaView {
+    return [self.adapter respondsToSelector:@selector(mainMediaView)] &&
+    [self.adapter mainMediaView] &&
+    [self.adView respondsToSelector:@selector(nativeMainImageView)];
+}
+
+/// Check the ad view is superView or not, if not adView will move to superView.
+- (void)adViewWillMoveToSuperview:(UIView *)superview {
+    self.adViewInViewHierarchy = (superview != nil);
+
+    if (superview) {
+        // We'll start asychronously loading the native ad images now.
+        if (self.adapter.properties[kAdIconImageKey] &&
+            [self.adView respondsToSelector:@selector(nativeIconImageView)]) {
+            //[self.rendererImageHandler
+            // loadImageForURL:[NSURL URLWithString:self.adapter.properties[kAdIconImageKey]]
+            // intoImageView:self.adView.nativeIconImageView];
+        }
+
+        // Only handle the loading of the main image if the adapter doesn't already have a view for it.
+        if (!([self.adapter respondsToSelector:@selector(mainMediaView)] &&
+              [self.adapter mainMediaView])) {
+            if (self.adapter.properties[kAdMainImageKey] &&
+                [self.adView respondsToSelector:@selector(nativeMainImageView)]) {
+                //[self.rendererImageHandler
+                // loadImageForURL:[NSURL URLWithString:self.adapter.properties[kAdMainImageKey]]
+                // intoImageView:self.adView.nativeMainImageView];
+            }
+        }
+
+        // Lay out custom assets here as the custom assets may contain images that need to be loaded.
+        if ([self.adView respondsToSelector:@selector(layoutCustomAssetsWithProperties:imageLoader:)]) {
+            // Create a simplified image loader for the ad view to use.
+            MPNativeAdRenderingImageLoader *imageLoader =
+            [[MPNativeAdRenderingImageLoader alloc] initWithImageHandler:self.rendererImageHandler];
+            [self.adView layoutCustomAssetsWithProperties:self.adapter.properties
+                                              imageLoader:imageLoader];
+        }
+    }
+}
+
+#pragma mark - MPNativeAdRendererImageHandlerDelegate
+
+- (BOOL)nativeAdViewInViewHierarchy {
+    return self.adViewInViewHierarchy;
+}
+
+@end
 

--- a/AdMob/MPGoogleAdMobNativeRenderer.m
+++ b/AdMob/MPGoogleAdMobNativeRenderer.m
@@ -17,7 +17,7 @@
 #import "MPGoogleAdMobNativeAdAdapter.h"
 #import "UIView+MPGoogleAdMobAdditions.h"
 
-@interface MPGoogleAdMobNativeRenderer () <MPNativeAdRendererImageHandlerDelegate>
+@interface MPGoogleAdMobNativeRenderer ()<MPNativeAdRendererImageHandlerDelegate>
 
 /// Publisher adView which is rendering.
 @property(nonatomic, strong) UIView<MPNativeAdRendering> *adView;
@@ -51,7 +51,7 @@
     config.rendererClass = [self class];
     config.rendererSettings = rendererSettings;
     config.supportedCustomEvents = @[ @"MPGoogleAdMobNativeCustomEvent" ];
-
+    
     return config;
 }
 
@@ -66,7 +66,7 @@
         _rendererImageHandler = [MPNativeAdRendererImageHandler new];
         _rendererImageHandler.delegate = self;
     }
-
+    
     return self;
 }
 
@@ -77,27 +77,27 @@
         if (error) {
             *error = MPNativeAdNSErrorForRenderValueTypeError();
         }
-
+        
         return nil;
     }
-
+    
     self.adapter = (MPGoogleAdMobNativeAdAdapter *)adapter;
-
+    
     if ([self.renderingViewClass respondsToSelector:@selector(nibForAd)]) {
         self.adView = (UIView<MPNativeAdRendering> *)[
                                                       [[self.renderingViewClass nibForAd] instantiateWithOwner:nil options:nil] firstObject];
     } else {
         self.adView = [[self.renderingViewClass alloc] init];
     }
-
+    
     self.adView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-
+    
     if (self.adapter.adMobNativeAppInstallAd) {
         [self renderAppInstallAdViewWithAdapter:self.adapter];
     } else {
         [self renderContentAdViewWithAdapter:self.adapter];
     }
-
+    
     return self.adView;
 }
 
@@ -109,7 +109,7 @@
     GADNativeAppInstallAdView *gadAppInstallAdView = [[GADNativeAppInstallAdView alloc] init];
     [self.adView addSubview:gadAppInstallAdView];
     [gadAppInstallAdView gad_fillSuperview];
-
+    
     gadAppInstallAdView.adChoicesView = (GADAdChoicesView *)[self.adapter privacyInformationIconView];
     gadAppInstallAdView.nativeAppInstallAd = self.adapter.adMobNativeAppInstallAd;
     if ([self.adView respondsToSelector:@selector(nativeTitleTextLabel)]) {
@@ -121,7 +121,7 @@
         [headlineView gad_fillSuperview];
         self.adView.nativeTitleTextLabel.text = adapter.properties[kAdTitleKey];
     }
-
+    
     if ([self.adView respondsToSelector:@selector(nativeMainTextLabel)]) {
         UILabel *bodyView = [[UILabel alloc] initWithFrame:CGRectZero];
         bodyView.text = self.adapter.adMobNativeAppInstallAd.body;
@@ -131,7 +131,7 @@
         [bodyView gad_fillSuperview];
         self.adView.nativeMainTextLabel.text = adapter.properties[kAdTextKey];
     }
-
+    
     if ([self.adView respondsToSelector:@selector(nativeCallToActionTextLabel)] &&
         self.adView.nativeCallToActionTextLabel) {
         UILabel *callToActionView = [[UILabel alloc] initWithFrame:CGRectZero];
@@ -142,7 +142,7 @@
         [callToActionView gad_fillSuperview];
         self.adView.nativeCallToActionTextLabel.text = adapter.properties[kAdCTATextKey];
     }
-
+    
     // We delay loading of images until the view is added to the view hierarchy so we don't
     // unnecessarily load images from the cache if the user is scrolling fast. So we will just store
     // the image URLs for now.
@@ -156,7 +156,7 @@
         [self.adView.nativeMainImageView addSubview:mainMediaImageView];
         [mainMediaImageView gad_fillSuperview];
     }
-
+    
     if ([self.adView respondsToSelector:@selector(nativeIconImageView)]) {
         NSString *iconImageURLString = adapter.properties[kAdIconImageKey];
         GADNativeAdImage *nativeAdImage =
@@ -167,7 +167,7 @@
         [self.adView.nativeIconImageView addSubview:iconView];
         [iconView gad_fillSuperview];
     }
-
+    
     // See if the ad contains a star rating and notify the view if it does.
     if ([self.adView respondsToSelector:@selector(layoutStarRating:)]) {
         NSNumber *starRatingNum = adapter.properties[kAdStarRatingKey];
@@ -177,7 +177,7 @@
             [self.adView layoutStarRating:starRatingNum];
         }
     }
-
+    
     // See if the ad contains the nativePrivacyInformationIconImageView and add GADAdChoices view
     // as its subview if it does.
     if ([self.adView respondsToSelector:@selector(nativePrivacyInformationIconImageView)]) {
@@ -193,7 +193,7 @@
     GADNativeContentAdView *gadAppContentAdView = [[GADNativeContentAdView alloc] init];
     [self.adView addSubview:gadAppContentAdView];
     [gadAppContentAdView gad_fillSuperview];
-
+    
     gadAppContentAdView.adChoicesView = (GADAdChoicesView *)[self.adapter privacyInformationIconView];
     gadAppContentAdView.nativeContentAd = self.adapter.adMobNativeContentAd;
     if ([self.adView respondsToSelector:@selector(nativeTitleTextLabel)]) {
@@ -205,7 +205,7 @@
         [headlineView gad_fillSuperview];
         self.adView.nativeTitleTextLabel.text = adapter.properties[kAdTitleKey];
     }
-
+    
     if ([self.adView respondsToSelector:@selector(nativeMainTextLabel)]) {
         UILabel *bodyView = [[UILabel alloc] initWithFrame:CGRectZero];
         bodyView.text = self.adapter.adMobNativeContentAd.body;
@@ -215,7 +215,7 @@
         [bodyView gad_fillSuperview];
         self.adView.nativeMainTextLabel.text = adapter.properties[kAdTextKey];
     }
-
+    
     if ([self.adView respondsToSelector:@selector(nativeCallToActionTextLabel)] &&
         self.adView.nativeCallToActionTextLabel) {
         UILabel *callToActionView = [[UILabel alloc] initWithFrame:CGRectZero];
@@ -226,7 +226,7 @@
         [callToActionView gad_fillSuperview];
         self.adView.nativeCallToActionTextLabel.text = adapter.properties[kAdCTATextKey];
     }
-
+    
     // We delay loading of images until the view is added to the view hierarchy so we don't
     // unnecessarily load images from the cache if the user is scrolling fast. So we will just store
     // the image URLs for now.
@@ -240,7 +240,7 @@
         [self.adView.nativeMainImageView addSubview:mainMediaImageView];
         [mainMediaImageView gad_fillSuperview];
     }
-
+    
     if ([self.adView respondsToSelector:@selector(nativeIconImageView)]) {
         NSString *iconImageURLString = adapter.properties[kAdIconImageKey];
         GADNativeAdImage *nativeAdImage =
@@ -251,7 +251,7 @@
         [self.adView.nativeIconImageView addSubview:iconView];
         [iconView gad_fillSuperview];
     }
-
+    
     // See if the ad contains the nativePrivacyInformationIconImageView and add GADAdChoices view
     // as its subview if it does.
     if ([self.adView respondsToSelector:@selector(nativePrivacyInformationIconImageView)]) {
@@ -270,27 +270,27 @@
 /// Check the ad view is superView or not, if not adView will move to superView.
 - (void)adViewWillMoveToSuperview:(UIView *)superview {
     self.adViewInViewHierarchy = (superview != nil);
-
+    
     if (superview) {
         // We'll start asychronously loading the native ad images now.
         if (self.adapter.properties[kAdIconImageKey] &&
             [self.adView respondsToSelector:@selector(nativeIconImageView)]) {
             [self.rendererImageHandler
-            loadImageForURL:[NSURL URLWithString:self.adapter.properties[kAdIconImageKey]]
-            intoImageView:self.adView.nativeIconImageView];
+             loadImageForURL:[NSURL URLWithString:self.adapter.properties[kAdIconImageKey]]
+             intoImageView:self.adView.nativeIconImageView];
         }
-
+        
         // Only handle the loading of the main image if the adapter doesn't already have a view for it.
         if (!([self.adapter respondsToSelector:@selector(mainMediaView)] &&
               [self.adapter mainMediaView])) {
             if (self.adapter.properties[kAdMainImageKey] &&
                 [self.adView respondsToSelector:@selector(nativeMainImageView)]) {
                 [self.rendererImageHandler
-                loadImageForURL:[NSURL URLWithString:self.adapter.properties[kAdMainImageKey]]
-                intoImageView:self.adView.nativeMainImageView];
+                 loadImageForURL:[NSURL URLWithString:self.adapter.properties[kAdMainImageKey]]
+                 intoImageView:self.adView.nativeMainImageView];
             }
         }
-
+        
         // Lay out custom assets here as the custom assets may contain images that need to be loaded.
         if ([self.adView respondsToSelector:@selector(layoutCustomAssetsWithProperties:imageLoader:)]) {
             // Create a simplified image loader for the ad view to use.
@@ -309,4 +309,3 @@
 }
 
 @end
-

--- a/AdMob/MPGoogleAdMobNativeRenderer.m
+++ b/AdMob/MPGoogleAdMobNativeRenderer.m
@@ -1,6 +1,6 @@
 #import "MPGoogleAdMobNativeRenderer.h"
 
-#if __has_include(<MoPub/MoPub.h>)
+#if __has_include("MoPub.h")
     #import "MPAdDestinationDisplayAgent.h"
     #import "MPLogging.h"
     #import "MPNativeAdAdapter.h"
@@ -13,20 +13,6 @@
     #import "MPNativeCache.h"
     #import "MPNativeView.h"
     #import "MPStaticNativeAdRendererSettings.h"
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-// TODO: enable the imports (and code) below after the headers have been added to MoPubSDKFramework
-//    #import <MoPubSDKFramework/MPAdDestinationDisplayAgent.h>
-    #import <MoPubSDKFramework/MPLogging.h>
-    #import <MoPubSDKFramework/MPNativeAdAdapter.h>
-    #import <MoPubSDKFramework/MPNativeAdConstants.h>
-    #import <MoPubSDKFramework/MPNativeAdError.h>
-    #import <MoPubSDKFramework/MPNativeAdRendererConfiguration.h>
-//    #import <MoPubSDKFramework/MPNativeAdRendererImageHandler.h>
-    #import <MoPubSDKFramework/MPNativeAdRendering.h>
-    #import <MoPubSDKFramework/MPNativeAdRenderingImageLoader.h>
-//    #import <MoPubSDKFramework/MPNativeCache.h>
-//    #import <MoPubSDKFramework/MPNativeView.h>
-    #import <MoPubSDKFramework/MPStaticNativeAdRendererSettings.h>
 #endif
 #import "MPGoogleAdMobNativeAdAdapter.h"
 #import "UIView+MPGoogleAdMobAdditions.h"

--- a/AdMob/MPGoogleAdMobNativeRenderer.m
+++ b/AdMob/MPGoogleAdMobNativeRenderer.m
@@ -1,309 +1,326 @@
 #import "MPGoogleAdMobNativeRenderer.h"
 
-#import "MPAdDestinationDisplayAgent.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPAdDestinationDisplayAgent.h"
+    #import "MPLogging.h"
+    #import "MPNativeAdAdapter.h"
+    #import "MPNativeAdConstants.h"
+    #import "MPNativeAdError.h"
+    #import "MPNativeAdRendererConfiguration.h"
+    #import "MPNativeAdRendererImageHandler.h"
+    #import "MPNativeAdRendering.h"
+    #import "MPNativeAdRenderingImageLoader.h"
+    #import "MPNativeCache.h"
+    #import "MPNativeView.h"
+    #import "MPStaticNativeAdRendererSettings.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+// TODO: enable the imports (and code) below after the headers have been added to MoPubSDKFramework
+//    #import <MoPubSDKFramework/MPAdDestinationDisplayAgent.h>
+    #import <MoPubSDKFramework/MPLogging.h>
+    #import <MoPubSDKFramework/MPNativeAdAdapter.h>
+    #import <MoPubSDKFramework/MPNativeAdConstants.h>
+    #import <MoPubSDKFramework/MPNativeAdError.h>
+    #import <MoPubSDKFramework/MPNativeAdRendererConfiguration.h>
+//    #import <MoPubSDKFramework/MPNativeAdRendererImageHandler.h>
+    #import <MoPubSDKFramework/MPNativeAdRendering.h>
+    #import <MoPubSDKFramework/MPNativeAdRenderingImageLoader.h>
+//    #import <MoPubSDKFramework/MPNativeCache.h>
+//    #import <MoPubSDKFramework/MPNativeView.h>
+    #import <MoPubSDKFramework/MPStaticNativeAdRendererSettings.h>
+#endif
 #import "MPGoogleAdMobNativeAdAdapter.h"
-#import "MPLogging.h"
-#import "MPNativeAdAdapter.h"
-#import "MPNativeAdConstants.h"
-#import "MPNativeAdError.h"
-#import "MPNativeAdRendererConfiguration.h"
-#import "MPNativeAdRendererImageHandler.h"
-#import "MPNativeAdRendering.h"
-#import "MPNativeAdRenderingImageLoader.h"
-#import "MPNativeCache.h"
-#import "MPNativeView.h"
-#import "MPStaticNativeAdRendererSettings.h"
 #import "UIView+MPGoogleAdMobAdditions.h"
 
-@interface MPGoogleAdMobNativeRenderer ()<MPNativeAdRendererImageHandlerDelegate>
+//@interface MPGoogleAdMobNativeRenderer ()<MPNativeAdRendererImageHandlerDelegate>
+//
+///// Publisher adView which is rendering.
+//@property(nonatomic, strong) UIView<MPNativeAdRendering> *adView;
+//
+///// MPGoogleAdMobNativeAdAdapter instance.
+//@property(nonatomic, strong) MPGoogleAdMobNativeAdAdapter *adapter;
+//
+///// YES if adView is in view hierarchy.
+//@property(nonatomic, assign) BOOL adViewInViewHierarchy;
+//
+///// MPNativeAdRendererImageHandler instance.
+//@property(nonatomic, strong) MPNativeAdRendererImageHandler *rendererImageHandler;
+//
+///// Class of renderingViewClass.
+//@property(nonatomic, strong) Class renderingViewClass;
+//
+///// GADNativeAppInstallAdView instance.
+//@property(nonatomic, strong) GADNativeAppInstallAdView *appInstallAdView;
+//
+//@end
+//
+//@implementation MPGoogleAdMobNativeRenderer
+//
+//@synthesize viewSizeHandler;
+//
+///// Construct and return an MPNativeAdRendererConfiguration object, you must set all the properties
+///// on the configuration object.
+//+ (MPNativeAdRendererConfiguration *)rendererConfigurationWithRendererSettings:
+//(id<MPNativeAdRendererSettings>)rendererSettings {
+//    MPNativeAdRendererConfiguration *config = [[MPNativeAdRendererConfiguration alloc] init];
+//    config.rendererClass = [self class];
+//    config.rendererSettings = rendererSettings;
+//    config.supportedCustomEvents = @[ @"MPGoogleAdMobNativeCustomEvent" ];
+//
+//    return config;
+//}
+//
+///// Renderer settings are objects that allow you to expose configurable properties to the
+///// application. MPGoogleAdMobNativeRenderer renderer will be initialized with these settings.
+//- (instancetype)initWithRendererSettings:(id<MPNativeAdRendererSettings>)rendererSettings {
+//    if (self = [super init]) {
+//        MPStaticNativeAdRendererSettings *settings =
+//        (MPStaticNativeAdRendererSettings *)rendererSettings;
+//        _renderingViewClass = settings.renderingViewClass;
+//        viewSizeHandler = [settings.viewSizeHandler copy];
+//        _rendererImageHandler = [MPNativeAdRendererImageHandler new];
+//        _rendererImageHandler.delegate = self;
+//    }
+//
+//    return self;
+//}
+//
+///// Returns an ad view rendered using provided |adapter|. Sets an |error| if any error is
+///// encountered.
+//- (UIView *)retrieveViewWithAdapter:(id<MPNativeAdAdapter>)adapter error:(NSError **)error {
+//    if (!adapter || ![adapter isKindOfClass:[MPGoogleAdMobNativeAdAdapter class]]) {
+//        if (error) {
+//            *error = MPNativeAdNSErrorForRenderValueTypeError();
+//        }
+//
+//        return nil;
+//    }
+//
+//    self.adapter = (MPGoogleAdMobNativeAdAdapter *)adapter;
+//
+//    if ([self.renderingViewClass respondsToSelector:@selector(nibForAd)]) {
+//        self.adView = (UIView<MPNativeAdRendering> *)[
+//                                                      [[self.renderingViewClass nibForAd] instantiateWithOwner:nil options:nil] firstObject];
+//    } else {
+//        self.adView = [[self.renderingViewClass alloc] init];
+//    }
+//
+//    self.adView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+//
+//    if (self.adapter.adMobNativeAppInstallAd) {
+//        [self renderAppInstallAdViewWithAdapter:self.adapter];
+//    } else {
+//        [self renderContentAdViewWithAdapter:self.adapter];
+//    }
+//
+//    return self.adView;
+//}
+//
+///// Creates native app install ad view with adapter. We added GADNativeAppInstallAdView assets on
+///// top of MoPub's adView, to track impressions & clicks.
+//- (void)renderAppInstallAdViewWithAdapter:(id<MPNativeAdAdapter>)adapter {
+//    // We only load text here. We're creating the GADNativeAppInstallAdView and preparing text
+//    // assets.
+//    GADNativeAppInstallAdView *gadAppInstallAdView = [[GADNativeAppInstallAdView alloc] init];
+//    [self.adView addSubview:gadAppInstallAdView];
+//    [gadAppInstallAdView gad_fillSuperview];
+//
+//    gadAppInstallAdView.adChoicesView = (GADAdChoicesView *)[self.adapter privacyInformationIconView];
+//    gadAppInstallAdView.nativeAppInstallAd = self.adapter.adMobNativeAppInstallAd;
+//    if ([self.adView respondsToSelector:@selector(nativeTitleTextLabel)]) {
+//        UILabel *headlineView = [[UILabel alloc] initWithFrame:CGRectZero];
+//        headlineView.text = self.adapter.adMobNativeAppInstallAd.headline;
+//        headlineView.textColor = [UIColor clearColor];
+//        gadAppInstallAdView.headlineView = headlineView;
+//        [self.adView.nativeTitleTextLabel addSubview:headlineView];
+//        [headlineView gad_fillSuperview];
+//        self.adView.nativeTitleTextLabel.text = adapter.properties[kAdTitleKey];
+//    }
+//
+//    if ([self.adView respondsToSelector:@selector(nativeMainTextLabel)]) {
+//        UILabel *bodyView = [[UILabel alloc] initWithFrame:CGRectZero];
+//        bodyView.text = self.adapter.adMobNativeAppInstallAd.body;
+//        bodyView.textColor = [UIColor clearColor];
+//        gadAppInstallAdView.bodyView = bodyView;
+//        [self.adView.nativeMainTextLabel addSubview:bodyView];
+//        [bodyView gad_fillSuperview];
+//        self.adView.nativeMainTextLabel.text = adapter.properties[kAdTextKey];
+//    }
+//
+//    if ([self.adView respondsToSelector:@selector(nativeCallToActionTextLabel)] &&
+//        self.adView.nativeCallToActionTextLabel) {
+//        UILabel *callToActionView = [[UILabel alloc] initWithFrame:CGRectZero];
+//        callToActionView.text = self.adapter.adMobNativeAppInstallAd.callToAction;
+//        callToActionView.textColor = [UIColor clearColor];
+//        gadAppInstallAdView.callToActionView = callToActionView;
+//        [self.adView.nativeCallToActionTextLabel addSubview:callToActionView];
+//        [callToActionView gad_fillSuperview];
+//        self.adView.nativeCallToActionTextLabel.text = adapter.properties[kAdCTATextKey];
+//    }
+//
+//    // We delay loading of images until the view is added to the view hierarchy so we don't
+//    // unnecessarily load images from the cache if the user is scrolling fast. So we will just store
+//    // the image URLs for now.
+//    if ([self.adView respondsToSelector:@selector(nativeMainImageView)]) {
+//        NSString *mainImageURLString = adapter.properties[kAdMainImageKey];
+//        GADNativeAdImage *nativeAdImage =
+//        [[GADNativeAdImage alloc] initWithURL:[NSURL URLWithString:mainImageURLString] scale:1];
+//        UIImageView *mainMediaImageView = [[UIImageView alloc] initWithFrame:CGRectZero];
+//        mainMediaImageView.image = nativeAdImage.image;
+//        gadAppInstallAdView.imageView = mainMediaImageView;
+//        [self.adView.nativeMainImageView addSubview:mainMediaImageView];
+//        [mainMediaImageView gad_fillSuperview];
+//    }
+//
+//    if ([self.adView respondsToSelector:@selector(nativeIconImageView)]) {
+//        NSString *iconImageURLString = adapter.properties[kAdIconImageKey];
+//        GADNativeAdImage *nativeAdImage =
+//        [[GADNativeAdImage alloc] initWithURL:[NSURL URLWithString:iconImageURLString] scale:1];
+//        UIImageView *iconView = [[UIImageView alloc] initWithFrame:CGRectZero];
+//        iconView.image = nativeAdImage.image;
+//        gadAppInstallAdView.iconView = iconView;
+//        [self.adView.nativeIconImageView addSubview:iconView];
+//        [iconView gad_fillSuperview];
+//    }
+//
+//    // See if the ad contains a star rating and notify the view if it does.
+//    if ([self.adView respondsToSelector:@selector(layoutStarRating:)]) {
+//        NSNumber *starRatingNum = adapter.properties[kAdStarRatingKey];
+//        if ([starRatingNum isKindOfClass:[NSNumber class]] &&
+//            starRatingNum.floatValue >= kStarRatingMinValue &&
+//            starRatingNum.floatValue <= kStarRatingMaxValue) {
+//            [self.adView layoutStarRating:starRatingNum];
+//        }
+//    }
+//
+//    // See if the ad contains the nativePrivacyInformationIconImageView and add GADAdChoices view
+//    // as its subview if it does.
+//    if ([self.adView respondsToSelector:@selector(nativePrivacyInformationIconImageView)]) {
+//        [self.adView.nativePrivacyInformationIconImageView
+//         addSubview:gadAppInstallAdView.adChoicesView];
+//    }
+//}
+//
+///// Creates native app content ad view with adapter. We added GADNativeContentAdView assets on top
+///// of MoPub's adView, to track impressions & clicks.
+//- (void)renderContentAdViewWithAdapter:(id<MPNativeAdAdapter>)adapter {
+//    // We only load text here. We're creating the GADNativeContentAdView and preparing text assets.
+//    GADNativeContentAdView *gadAppContentAdView = [[GADNativeContentAdView alloc] init];
+//    [self.adView addSubview:gadAppContentAdView];
+//    [gadAppContentAdView gad_fillSuperview];
+//
+//    gadAppContentAdView.adChoicesView = (GADAdChoicesView *)[self.adapter privacyInformationIconView];
+//    gadAppContentAdView.nativeContentAd = self.adapter.adMobNativeContentAd;
+//    if ([self.adView respondsToSelector:@selector(nativeTitleTextLabel)]) {
+//        UILabel *headlineView = [[UILabel alloc] initWithFrame:CGRectZero];
+//        headlineView.text = self.adapter.adMobNativeContentAd.headline;
+//        headlineView.textColor = [UIColor clearColor];
+//        gadAppContentAdView.headlineView = headlineView;
+//        [self.adView.nativeTitleTextLabel addSubview:headlineView];
+//        [headlineView gad_fillSuperview];
+//        self.adView.nativeTitleTextLabel.text = adapter.properties[kAdTitleKey];
+//    }
+//
+//    if ([self.adView respondsToSelector:@selector(nativeMainTextLabel)]) {
+//        UILabel *bodyView = [[UILabel alloc] initWithFrame:CGRectZero];
+//        bodyView.text = self.adapter.adMobNativeContentAd.body;
+//        bodyView.textColor = [UIColor clearColor];
+//        gadAppContentAdView.bodyView = bodyView;
+//        [self.adView.nativeMainTextLabel addSubview:bodyView];
+//        [bodyView gad_fillSuperview];
+//        self.adView.nativeMainTextLabel.text = adapter.properties[kAdTextKey];
+//    }
+//
+//    if ([self.adView respondsToSelector:@selector(nativeCallToActionTextLabel)] &&
+//        self.adView.nativeCallToActionTextLabel) {
+//        UILabel *callToActionView = [[UILabel alloc] initWithFrame:CGRectZero];
+//        callToActionView.text = self.adapter.adMobNativeContentAd.callToAction;
+//        callToActionView.textColor = [UIColor clearColor];
+//        gadAppContentAdView.callToActionView = callToActionView;
+//        [self.adView.nativeCallToActionTextLabel addSubview:callToActionView];
+//        [callToActionView gad_fillSuperview];
+//        self.adView.nativeCallToActionTextLabel.text = adapter.properties[kAdCTATextKey];
+//    }
+//
+//    // We delay loading of images until the view is added to the view hierarchy so we don't
+//    // unnecessarily load images from the cache if the user is scrolling fast. So we will just store
+//    // the image URLs for now.
+//    if ([self.adView respondsToSelector:@selector(nativeMainImageView)]) {
+//        NSString *mainImageURLString = adapter.properties[kAdMainImageKey];
+//        GADNativeAdImage *nativeAdImage =
+//        [[GADNativeAdImage alloc] initWithURL:[NSURL URLWithString:mainImageURLString] scale:1];
+//        UIImageView *mainMediaImageView = [[UIImageView alloc] initWithFrame:CGRectZero];
+//        mainMediaImageView.image = nativeAdImage.image;
+//        gadAppContentAdView.imageView = mainMediaImageView;
+//        [self.adView.nativeMainImageView addSubview:mainMediaImageView];
+//        [mainMediaImageView gad_fillSuperview];
+//    }
+//
+//    if ([self.adView respondsToSelector:@selector(nativeIconImageView)]) {
+//        NSString *iconImageURLString = adapter.properties[kAdIconImageKey];
+//        GADNativeAdImage *nativeAdImage =
+//        [[GADNativeAdImage alloc] initWithURL:[NSURL URLWithString:iconImageURLString] scale:1];
+//        UIImageView *iconView = [[UIImageView alloc] initWithFrame:CGRectZero];
+//        iconView.image = nativeAdImage.image;
+//        gadAppContentAdView.logoView = iconView;
+//        [self.adView.nativeIconImageView addSubview:iconView];
+//        [iconView gad_fillSuperview];
+//    }
+//
+//    // See if the ad contains the nativePrivacyInformationIconImageView and add GADAdChoices view
+//    // as its subview if it does.
+//    if ([self.adView respondsToSelector:@selector(nativePrivacyInformationIconImageView)]) {
+//        [self.adView.nativePrivacyInformationIconImageView
+//         addSubview:gadAppContentAdView.adChoicesView];
+//    }
+//}
+//
+///// Checks whether the ad view contains media.
+//- (BOOL)shouldLoadMediaView {
+//    return [self.adapter respondsToSelector:@selector(mainMediaView)] &&
+//    [self.adapter mainMediaView] &&
+//    [self.adView respondsToSelector:@selector(nativeMainImageView)];
+//}
+//
+///// Check the ad view is superView or not, if not adView will move to superView.
+//- (void)adViewWillMoveToSuperview:(UIView *)superview {
+//    self.adViewInViewHierarchy = (superview != nil);
+//
+//    if (superview) {
+//        // We'll start asychronously loading the native ad images now.
+//        if (self.adapter.properties[kAdIconImageKey] &&
+//            [self.adView respondsToSelector:@selector(nativeIconImageView)]) {
+//            [self.rendererImageHandler
+//             loadImageForURL:[NSURL URLWithString:self.adapter.properties[kAdIconImageKey]]
+//             intoImageView:self.adView.nativeIconImageView];
+//        }
+//
+//        // Only handle the loading of the main image if the adapter doesn't already have a view for it.
+//        if (!([self.adapter respondsToSelector:@selector(mainMediaView)] &&
+//              [self.adapter mainMediaView])) {
+//            if (self.adapter.properties[kAdMainImageKey] &&
+//                [self.adView respondsToSelector:@selector(nativeMainImageView)]) {
+//                [self.rendererImageHandler
+//                 loadImageForURL:[NSURL URLWithString:self.adapter.properties[kAdMainImageKey]]
+//                 intoImageView:self.adView.nativeMainImageView];
+//            }
+//        }
+//
+//        // Lay out custom assets here as the custom assets may contain images that need to be loaded.
+//        if ([self.adView respondsToSelector:@selector(layoutCustomAssetsWithProperties:imageLoader:)]) {
+//            // Create a simplified image loader for the ad view to use.
+//            MPNativeAdRenderingImageLoader *imageLoader =
+//            [[MPNativeAdRenderingImageLoader alloc] initWithImageHandler:self.rendererImageHandler];
+//            [self.adView layoutCustomAssetsWithProperties:self.adapter.properties
+//                                              imageLoader:imageLoader];
+//        }
+//    }
+//}
+//
+//#pragma mark - MPNativeAdRendererImageHandlerDelegate
+//
+//- (BOOL)nativeAdViewInViewHierarchy {
+//    return self.adViewInViewHierarchy;
+//}
+//
+//@end
 
-/// Publisher adView which is rendering.
-@property(nonatomic, strong) UIView<MPNativeAdRendering> *adView;
-
-/// MPGoogleAdMobNativeAdAdapter instance.
-@property(nonatomic, strong) MPGoogleAdMobNativeAdAdapter *adapter;
-
-/// YES if adView is in view hierarchy.
-@property(nonatomic, assign) BOOL adViewInViewHierarchy;
-
-/// MPNativeAdRendererImageHandler instance.
-@property(nonatomic, strong) MPNativeAdRendererImageHandler *rendererImageHandler;
-
-/// Class of renderingViewClass.
-@property(nonatomic, strong) Class renderingViewClass;
-
-/// GADNativeAppInstallAdView instance.
-@property(nonatomic, strong) GADNativeAppInstallAdView *appInstallAdView;
-
-@end
-
-@implementation MPGoogleAdMobNativeRenderer
-
-@synthesize viewSizeHandler;
-
-/// Construct and return an MPNativeAdRendererConfiguration object, you must set all the properties
-/// on the configuration object.
-+ (MPNativeAdRendererConfiguration *)rendererConfigurationWithRendererSettings:
-(id<MPNativeAdRendererSettings>)rendererSettings {
-    MPNativeAdRendererConfiguration *config = [[MPNativeAdRendererConfiguration alloc] init];
-    config.rendererClass = [self class];
-    config.rendererSettings = rendererSettings;
-    config.supportedCustomEvents = @[ @"MPGoogleAdMobNativeCustomEvent" ];
-    
-    return config;
-}
-
-/// Renderer settings are objects that allow you to expose configurable properties to the
-/// application. MPGoogleAdMobNativeRenderer renderer will be initialized with these settings.
-- (instancetype)initWithRendererSettings:(id<MPNativeAdRendererSettings>)rendererSettings {
-    if (self = [super init]) {
-        MPStaticNativeAdRendererSettings *settings =
-        (MPStaticNativeAdRendererSettings *)rendererSettings;
-        _renderingViewClass = settings.renderingViewClass;
-        viewSizeHandler = [settings.viewSizeHandler copy];
-        _rendererImageHandler = [MPNativeAdRendererImageHandler new];
-        _rendererImageHandler.delegate = self;
-    }
-    
-    return self;
-}
-
-/// Returns an ad view rendered using provided |adapter|. Sets an |error| if any error is
-/// encountered.
-- (UIView *)retrieveViewWithAdapter:(id<MPNativeAdAdapter>)adapter error:(NSError **)error {
-    if (!adapter || ![adapter isKindOfClass:[MPGoogleAdMobNativeAdAdapter class]]) {
-        if (error) {
-            *error = MPNativeAdNSErrorForRenderValueTypeError();
-        }
-        
-        return nil;
-    }
-    
-    self.adapter = (MPGoogleAdMobNativeAdAdapter *)adapter;
-    
-    if ([self.renderingViewClass respondsToSelector:@selector(nibForAd)]) {
-        self.adView = (UIView<MPNativeAdRendering> *)[
-                                                      [[self.renderingViewClass nibForAd] instantiateWithOwner:nil options:nil] firstObject];
-    } else {
-        self.adView = [[self.renderingViewClass alloc] init];
-    }
-    
-    self.adView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-    
-    if (self.adapter.adMobNativeAppInstallAd) {
-        [self renderAppInstallAdViewWithAdapter:self.adapter];
-    } else {
-        [self renderContentAdViewWithAdapter:self.adapter];
-    }
-    
-    return self.adView;
-}
-
-/// Creates native app install ad view with adapter. We added GADNativeAppInstallAdView assets on
-/// top of MoPub's adView, to track impressions & clicks.
-- (void)renderAppInstallAdViewWithAdapter:(id<MPNativeAdAdapter>)adapter {
-    // We only load text here. We're creating the GADNativeAppInstallAdView and preparing text
-    // assets.
-    GADNativeAppInstallAdView *gadAppInstallAdView = [[GADNativeAppInstallAdView alloc] init];
-    [self.adView addSubview:gadAppInstallAdView];
-    [gadAppInstallAdView gad_fillSuperview];
-    
-    gadAppInstallAdView.adChoicesView = (GADAdChoicesView *)[self.adapter privacyInformationIconView];
-    gadAppInstallAdView.nativeAppInstallAd = self.adapter.adMobNativeAppInstallAd;
-    if ([self.adView respondsToSelector:@selector(nativeTitleTextLabel)]) {
-        UILabel *headlineView = [[UILabel alloc] initWithFrame:CGRectZero];
-        headlineView.text = self.adapter.adMobNativeAppInstallAd.headline;
-        headlineView.textColor = [UIColor clearColor];
-        gadAppInstallAdView.headlineView = headlineView;
-        [self.adView.nativeTitleTextLabel addSubview:headlineView];
-        [headlineView gad_fillSuperview];
-        self.adView.nativeTitleTextLabel.text = adapter.properties[kAdTitleKey];
-    }
-    
-    if ([self.adView respondsToSelector:@selector(nativeMainTextLabel)]) {
-        UILabel *bodyView = [[UILabel alloc] initWithFrame:CGRectZero];
-        bodyView.text = self.adapter.adMobNativeAppInstallAd.body;
-        bodyView.textColor = [UIColor clearColor];
-        gadAppInstallAdView.bodyView = bodyView;
-        [self.adView.nativeMainTextLabel addSubview:bodyView];
-        [bodyView gad_fillSuperview];
-        self.adView.nativeMainTextLabel.text = adapter.properties[kAdTextKey];
-    }
-    
-    if ([self.adView respondsToSelector:@selector(nativeCallToActionTextLabel)] &&
-        self.adView.nativeCallToActionTextLabel) {
-        UILabel *callToActionView = [[UILabel alloc] initWithFrame:CGRectZero];
-        callToActionView.text = self.adapter.adMobNativeAppInstallAd.callToAction;
-        callToActionView.textColor = [UIColor clearColor];
-        gadAppInstallAdView.callToActionView = callToActionView;
-        [self.adView.nativeCallToActionTextLabel addSubview:callToActionView];
-        [callToActionView gad_fillSuperview];
-        self.adView.nativeCallToActionTextLabel.text = adapter.properties[kAdCTATextKey];
-    }
-    
-    // We delay loading of images until the view is added to the view hierarchy so we don't
-    // unnecessarily load images from the cache if the user is scrolling fast. So we will just store
-    // the image URLs for now.
-    if ([self.adView respondsToSelector:@selector(nativeMainImageView)]) {
-        NSString *mainImageURLString = adapter.properties[kAdMainImageKey];
-        GADNativeAdImage *nativeAdImage =
-        [[GADNativeAdImage alloc] initWithURL:[NSURL URLWithString:mainImageURLString] scale:1];
-        UIImageView *mainMediaImageView = [[UIImageView alloc] initWithFrame:CGRectZero];
-        mainMediaImageView.image = nativeAdImage.image;
-        gadAppInstallAdView.imageView = mainMediaImageView;
-        [self.adView.nativeMainImageView addSubview:mainMediaImageView];
-        [mainMediaImageView gad_fillSuperview];
-    }
-    
-    if ([self.adView respondsToSelector:@selector(nativeIconImageView)]) {
-        NSString *iconImageURLString = adapter.properties[kAdIconImageKey];
-        GADNativeAdImage *nativeAdImage =
-        [[GADNativeAdImage alloc] initWithURL:[NSURL URLWithString:iconImageURLString] scale:1];
-        UIImageView *iconView = [[UIImageView alloc] initWithFrame:CGRectZero];
-        iconView.image = nativeAdImage.image;
-        gadAppInstallAdView.iconView = iconView;
-        [self.adView.nativeIconImageView addSubview:iconView];
-        [iconView gad_fillSuperview];
-    }
-    
-    // See if the ad contains a star rating and notify the view if it does.
-    if ([self.adView respondsToSelector:@selector(layoutStarRating:)]) {
-        NSNumber *starRatingNum = adapter.properties[kAdStarRatingKey];
-        if ([starRatingNum isKindOfClass:[NSNumber class]] &&
-            starRatingNum.floatValue >= kStarRatingMinValue &&
-            starRatingNum.floatValue <= kStarRatingMaxValue) {
-            [self.adView layoutStarRating:starRatingNum];
-        }
-    }
-    
-    // See if the ad contains the nativePrivacyInformationIconImageView and add GADAdChoices view
-    // as its subview if it does.
-    if ([self.adView respondsToSelector:@selector(nativePrivacyInformationIconImageView)]) {
-        [self.adView.nativePrivacyInformationIconImageView
-         addSubview:gadAppInstallAdView.adChoicesView];
-    }
-}
-
-/// Creates native app content ad view with adapter. We added GADNativeContentAdView assets on top
-/// of MoPub's adView, to track impressions & clicks.
-- (void)renderContentAdViewWithAdapter:(id<MPNativeAdAdapter>)adapter {
-    // We only load text here. We're creating the GADNativeContentAdView and preparing text assets.
-    GADNativeContentAdView *gadAppContentAdView = [[GADNativeContentAdView alloc] init];
-    [self.adView addSubview:gadAppContentAdView];
-    [gadAppContentAdView gad_fillSuperview];
-    
-    gadAppContentAdView.adChoicesView = (GADAdChoicesView *)[self.adapter privacyInformationIconView];
-    gadAppContentAdView.nativeContentAd = self.adapter.adMobNativeContentAd;
-    if ([self.adView respondsToSelector:@selector(nativeTitleTextLabel)]) {
-        UILabel *headlineView = [[UILabel alloc] initWithFrame:CGRectZero];
-        headlineView.text = self.adapter.adMobNativeContentAd.headline;
-        headlineView.textColor = [UIColor clearColor];
-        gadAppContentAdView.headlineView = headlineView;
-        [self.adView.nativeTitleTextLabel addSubview:headlineView];
-        [headlineView gad_fillSuperview];
-        self.adView.nativeTitleTextLabel.text = adapter.properties[kAdTitleKey];
-    }
-    
-    if ([self.adView respondsToSelector:@selector(nativeMainTextLabel)]) {
-        UILabel *bodyView = [[UILabel alloc] initWithFrame:CGRectZero];
-        bodyView.text = self.adapter.adMobNativeContentAd.body;
-        bodyView.textColor = [UIColor clearColor];
-        gadAppContentAdView.bodyView = bodyView;
-        [self.adView.nativeMainTextLabel addSubview:bodyView];
-        [bodyView gad_fillSuperview];
-        self.adView.nativeMainTextLabel.text = adapter.properties[kAdTextKey];
-    }
-    
-    if ([self.adView respondsToSelector:@selector(nativeCallToActionTextLabel)] &&
-        self.adView.nativeCallToActionTextLabel) {
-        UILabel *callToActionView = [[UILabel alloc] initWithFrame:CGRectZero];
-        callToActionView.text = self.adapter.adMobNativeContentAd.callToAction;
-        callToActionView.textColor = [UIColor clearColor];
-        gadAppContentAdView.callToActionView = callToActionView;
-        [self.adView.nativeCallToActionTextLabel addSubview:callToActionView];
-        [callToActionView gad_fillSuperview];
-        self.adView.nativeCallToActionTextLabel.text = adapter.properties[kAdCTATextKey];
-    }
-    
-    // We delay loading of images until the view is added to the view hierarchy so we don't
-    // unnecessarily load images from the cache if the user is scrolling fast. So we will just store
-    // the image URLs for now.
-    if ([self.adView respondsToSelector:@selector(nativeMainImageView)]) {
-        NSString *mainImageURLString = adapter.properties[kAdMainImageKey];
-        GADNativeAdImage *nativeAdImage =
-        [[GADNativeAdImage alloc] initWithURL:[NSURL URLWithString:mainImageURLString] scale:1];
-        UIImageView *mainMediaImageView = [[UIImageView alloc] initWithFrame:CGRectZero];
-        mainMediaImageView.image = nativeAdImage.image;
-        gadAppContentAdView.imageView = mainMediaImageView;
-        [self.adView.nativeMainImageView addSubview:mainMediaImageView];
-        [mainMediaImageView gad_fillSuperview];
-    }
-    
-    if ([self.adView respondsToSelector:@selector(nativeIconImageView)]) {
-        NSString *iconImageURLString = adapter.properties[kAdIconImageKey];
-        GADNativeAdImage *nativeAdImage =
-        [[GADNativeAdImage alloc] initWithURL:[NSURL URLWithString:iconImageURLString] scale:1];
-        UIImageView *iconView = [[UIImageView alloc] initWithFrame:CGRectZero];
-        iconView.image = nativeAdImage.image;
-        gadAppContentAdView.logoView = iconView;
-        [self.adView.nativeIconImageView addSubview:iconView];
-        [iconView gad_fillSuperview];
-    }
-    
-    // See if the ad contains the nativePrivacyInformationIconImageView and add GADAdChoices view
-    // as its subview if it does.
-    if ([self.adView respondsToSelector:@selector(nativePrivacyInformationIconImageView)]) {
-        [self.adView.nativePrivacyInformationIconImageView
-         addSubview:gadAppContentAdView.adChoicesView];
-    }
-}
-
-/// Checks whether the ad view contains media.
-- (BOOL)shouldLoadMediaView {
-    return [self.adapter respondsToSelector:@selector(mainMediaView)] &&
-    [self.adapter mainMediaView] &&
-    [self.adView respondsToSelector:@selector(nativeMainImageView)];
-}
-
-/// Check the ad view is superView or not, if not adView will move to superView.
-- (void)adViewWillMoveToSuperview:(UIView *)superview {
-    self.adViewInViewHierarchy = (superview != nil);
-    
-    if (superview) {
-        // We'll start asychronously loading the native ad images now.
-        if (self.adapter.properties[kAdIconImageKey] &&
-            [self.adView respondsToSelector:@selector(nativeIconImageView)]) {
-            [self.rendererImageHandler
-             loadImageForURL:[NSURL URLWithString:self.adapter.properties[kAdIconImageKey]]
-             intoImageView:self.adView.nativeIconImageView];
-        }
-        
-        // Only handle the loading of the main image if the adapter doesn't already have a view for it.
-        if (!([self.adapter respondsToSelector:@selector(mainMediaView)] &&
-              [self.adapter mainMediaView])) {
-            if (self.adapter.properties[kAdMainImageKey] &&
-                [self.adView respondsToSelector:@selector(nativeMainImageView)]) {
-                [self.rendererImageHandler
-                 loadImageForURL:[NSURL URLWithString:self.adapter.properties[kAdMainImageKey]]
-                 intoImageView:self.adView.nativeMainImageView];
-            }
-        }
-        
-        // Lay out custom assets here as the custom assets may contain images that need to be loaded.
-        if ([self.adView respondsToSelector:@selector(layoutCustomAssetsWithProperties:imageLoader:)]) {
-            // Create a simplified image loader for the ad view to use.
-            MPNativeAdRenderingImageLoader *imageLoader =
-            [[MPNativeAdRenderingImageLoader alloc] initWithImageHandler:self.rendererImageHandler];
-            [self.adView layoutCustomAssetsWithProperties:self.adapter.properties
-                                              imageLoader:imageLoader];
-        }
-    }
-}
-
-#pragma mark - MPNativeAdRendererImageHandlerDelegate
-
-- (BOOL)nativeAdViewInViewHierarchy {
-    return self.adViewInViewHierarchy;
-}
-
-@end

--- a/AdMob/MPGoogleAdMobNativeRenderer.m
+++ b/AdMob/MPGoogleAdMobNativeRenderer.m
@@ -17,7 +17,7 @@
 #import "MPGoogleAdMobNativeAdAdapter.h"
 #import "UIView+MPGoogleAdMobAdditions.h"
 
-@interface MPGoogleAdMobNativeRenderer () //<MPNativeAdRendererImageHandlerDelegate>
+@interface MPGoogleAdMobNativeRenderer () <MPNativeAdRendererImageHandlerDelegate>
 
 /// Publisher adView which is rendering.
 @property(nonatomic, strong) UIView<MPNativeAdRendering> *adView;
@@ -63,8 +63,8 @@
         (MPStaticNativeAdRendererSettings *)rendererSettings;
         _renderingViewClass = settings.renderingViewClass;
         viewSizeHandler = [settings.viewSizeHandler copy];
-        _rendererImageHandler = nil; //[MPNativeAdRendererImageHandler new];
-        //_rendererImageHandler.delegate = self;
+        _rendererImageHandler = [MPNativeAdRendererImageHandler new];
+        _rendererImageHandler.delegate = self;
     }
 
     return self;
@@ -275,9 +275,9 @@
         // We'll start asychronously loading the native ad images now.
         if (self.adapter.properties[kAdIconImageKey] &&
             [self.adView respondsToSelector:@selector(nativeIconImageView)]) {
-            //[self.rendererImageHandler
-            // loadImageForURL:[NSURL URLWithString:self.adapter.properties[kAdIconImageKey]]
-            // intoImageView:self.adView.nativeIconImageView];
+            [self.rendererImageHandler
+            loadImageForURL:[NSURL URLWithString:self.adapter.properties[kAdIconImageKey]]
+            intoImageView:self.adView.nativeIconImageView];
         }
 
         // Only handle the loading of the main image if the adapter doesn't already have a view for it.
@@ -285,9 +285,9 @@
               [self.adapter mainMediaView])) {
             if (self.adapter.properties[kAdMainImageKey] &&
                 [self.adView respondsToSelector:@selector(nativeMainImageView)]) {
-                //[self.rendererImageHandler
-                // loadImageForURL:[NSURL URLWithString:self.adapter.properties[kAdMainImageKey]]
-                // intoImageView:self.adView.nativeMainImageView];
+                [self.rendererImageHandler
+                loadImageForURL:[NSURL URLWithString:self.adapter.properties[kAdMainImageKey]]
+                intoImageView:self.adView.nativeMainImageView];
             }
         }
 

--- a/AdMob/MPGoogleAdMobRewardedVideoCustomEvent.m
+++ b/AdMob/MPGoogleAdMobRewardedVideoCustomEvent.m
@@ -1,10 +1,17 @@
 #import "MPGoogleAdMobRewardedVideoCustomEvent.h"
 
 #import <GoogleMobileAds/GoogleMobileAds.h>
-#import "MPLogging.h"
-#import "MPRewardedVideoError.h"
-#import "MPRewardedVideoReward.h"
-#import "MPRewardedVideoCustomEvent+Caching.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPLogging.h"
+    #import "MPRewardedVideoError.h"
+    #import "MPRewardedVideoReward.h"
+    #import "MPRewardedVideoCustomEvent+Caching.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPLogging.h>
+    #import <MoPubSDKFramework/MPRewardedVideoError.h>
+    #import <MoPubSDKFramework/MPRewardedVideoReward.h>
+    #import <MoPubSDKFramework/MPRewardedVideoCustomEvent+Caching.h>
+#endif
 
 @interface MPGoogleAdMobRewardedVideoCustomEvent () <GADRewardBasedVideoAdDelegate>
 

--- a/AdMob/MPGoogleAdMobRewardedVideoCustomEvent.m
+++ b/AdMob/MPGoogleAdMobRewardedVideoCustomEvent.m
@@ -1,16 +1,11 @@
 #import "MPGoogleAdMobRewardedVideoCustomEvent.h"
 
 #import <GoogleMobileAds/GoogleMobileAds.h>
-#if __has_include(<MoPub/MoPub.h>)
+#if __has_include("MoPub.h")
     #import "MPLogging.h"
     #import "MPRewardedVideoError.h"
     #import "MPRewardedVideoReward.h"
     #import "MPRewardedVideoCustomEvent+Caching.h"
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPLogging.h>
-    #import <MoPubSDKFramework/MPRewardedVideoError.h>
-    #import <MoPubSDKFramework/MPRewardedVideoReward.h>
-    #import <MoPubSDKFramework/MPRewardedVideoCustomEvent+Caching.h>
 #endif
 
 @interface MPGoogleAdMobRewardedVideoCustomEvent () <GADRewardBasedVideoAdDelegate>

--- a/AppLovin/AppLovinBannerCustomEvent.h
+++ b/AppLovin/AppLovinBannerCustomEvent.h
@@ -5,9 +5,11 @@
 //
 
 #if __has_include(<MoPub/MoPub.h>)
-    #import "MPBannerCustomEvent.h"
+    #import <MoPub/MoPub.h>
 #elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPBannerCustomEvent.h>
+    #import <MoPubSDKFramework/MoPub.h>
+#else
+    #import "MPBannerCustomEvent.h"
 #endif
 
 @interface AppLovinBannerCustomEvent : MPBannerCustomEvent

--- a/AppLovin/AppLovinBannerCustomEvent.h
+++ b/AppLovin/AppLovinBannerCustomEvent.h
@@ -4,7 +4,11 @@
 //
 //
 
-#import "MPBannerCustomEvent.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPBannerCustomEvent.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPBannerCustomEvent.h>
+#endif
 
 @interface AppLovinBannerCustomEvent : MPBannerCustomEvent
 

--- a/AppLovin/AppLovinBannerCustomEvent.m
+++ b/AppLovin/AppLovinBannerCustomEvent.m
@@ -3,15 +3,10 @@
 //
 
 #import "AppLovinInterstitialCustomEvent.h"
-#if __has_include(<MoPub/MoPub.h>)
+#if __has_include("MoPub.h")
     #import "MPError.h"
     #import "MPLogging.h"
     #import "MoPub.h"
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-// TODO: enable this import (and disabled code below) after MPError.h has been added to MoPubSDKFramework
-//    #import <MoPubSDKFramework/MPError.h>
-    #import <MoPubSDKFramework/MPLogging.h>
-    #import <MoPubSDKFramework/MoPub.h>
 #endif
 
 #if __has_include(<AppLovinSDK/AppLovinSDK.h>)
@@ -142,7 +137,7 @@ static NSObject *ALGlobalInterstitialAdsLock;
     [self log: @"Interstitial failed to load with error: %d", code];
     
     NSError *error = [NSError errorWithDomain: kALMoPubMediationErrorDomain
-                                         code: [self toMoPubErrorCode: code]
+                                         code: code //[self toMoPubErrorCode: code]
                                      userInfo: nil];
     
     dispatch_async(dispatch_get_main_queue(), ^{

--- a/AppLovin/AppLovinBannerCustomEvent.m
+++ b/AppLovin/AppLovinBannerCustomEvent.m
@@ -187,25 +187,25 @@ static NSMutableDictionary<NSString *, ALAdView *> *ALGlobalAdViews;
     MPLogDebug(@"AppLovinBannerCustomEvent : %@", message);
 }
 
-//- (MOPUBErrorCode)toMoPubErrorCode:(int)appLovinErrorCode
-//{
-//    if ( appLovinErrorCode == kALErrorCodeNoFill )
-//    {
-//        return MOPUBErrorAdapterHasNoInventory;
-//    }
-//    else if ( appLovinErrorCode == kALErrorCodeAdRequestNetworkTimeout )
-//    {
-//        return MOPUBErrorNetworkTimedOut;
-//    }
-//    else if ( appLovinErrorCode == kALErrorCodeInvalidResponse )
-//    {
-//        return MOPUBErrorServerError;
-//    }
-//    else
-//    {
-//        return MOPUBErrorUnknown;
-//    }
-//}
+- (MOPUBErrorCode)toMoPubErrorCode:(int)appLovinErrorCode
+{
+   if ( appLovinErrorCode == kALErrorCodeNoFill )
+   {
+       return MOPUBErrorAdapterHasNoInventory;
+   }
+   else if ( appLovinErrorCode == kALErrorCodeAdRequestNetworkTimeout )
+   {
+       return MOPUBErrorNetworkTimedOut;
+   }
+   else if ( appLovinErrorCode == kALErrorCodeInvalidResponse )
+   {
+       return MOPUBErrorServerError;
+   }
+   else
+   {
+       return MOPUBErrorUnknown;
+   }
+}
 
 - (ALSdk *)SDKFromCustomEventInfo:(NSDictionary *)info
 {
@@ -254,7 +254,7 @@ static NSMutableDictionary<NSString *, ALAdView *> *ALGlobalAdViews;
         [self.parentCustomEvent log: @"Banner failed to load with error: %d", code];
         
         NSError *error = [NSError errorWithDomain: kALMoPubMediationErrorDomain
-                                             code: code //[self.parentCustomEvent toMoPubErrorCode: code]
+                                             code: [self.parentCustomEvent toMoPubErrorCode: code]
                                          userInfo: nil];
         [self.parentCustomEvent.delegate bannerCustomEvent: self.parentCustomEvent didFailToLoadAdWithError: error];
     });
@@ -314,7 +314,7 @@ static NSMutableDictionary<NSString *, ALAdView *> *ALGlobalAdViews;
     [self.parentCustomEvent log: @"Banner failed to display: %ld", code];
     
     NSError *error = [NSError errorWithDomain: kALMoPubMediationErrorDomain
-                                         code: code //[self.parentCustomEvent toMoPubErrorCode: code]
+                                         code: [self.parentCustomEvent toMoPubErrorCode: code]
                                      userInfo: @{NSLocalizedFailureReasonErrorKey : @"Adaptor failed to display banner"}];
     [self.parentCustomEvent.delegate bannerCustomEvent: self.parentCustomEvent didFailToLoadAdWithError: error];
 }

--- a/AppLovin/AppLovinBannerCustomEvent.m
+++ b/AppLovin/AppLovinBannerCustomEvent.m
@@ -189,22 +189,22 @@ static NSMutableDictionary<NSString *, ALAdView *> *ALGlobalAdViews;
 
 - (MOPUBErrorCode)toMoPubErrorCode:(int)appLovinErrorCode
 {
-   if ( appLovinErrorCode == kALErrorCodeNoFill )
-   {
-       return MOPUBErrorAdapterHasNoInventory;
-   }
-   else if ( appLovinErrorCode == kALErrorCodeAdRequestNetworkTimeout )
-   {
-       return MOPUBErrorNetworkTimedOut;
-   }
-   else if ( appLovinErrorCode == kALErrorCodeInvalidResponse )
-   {
-       return MOPUBErrorServerError;
-   }
-   else
-   {
-       return MOPUBErrorUnknown;
-   }
+    if ( appLovinErrorCode == kALErrorCodeNoFill )
+    {
+        return MOPUBErrorAdapterHasNoInventory;
+    }
+    else if ( appLovinErrorCode == kALErrorCodeAdRequestNetworkTimeout )
+    {
+        return MOPUBErrorNetworkTimedOut;
+    }
+    else if ( appLovinErrorCode == kALErrorCodeInvalidResponse )
+    {
+        return MOPUBErrorServerError;
+    }
+    else
+    {
+        return MOPUBErrorUnknown;
+    }
 }
 
 - (ALSdk *)SDKFromCustomEventInfo:(NSDictionary *)info

--- a/AppLovin/AppLovinBannerCustomEvent.m
+++ b/AppLovin/AppLovinBannerCustomEvent.m
@@ -1,56 +1,59 @@
 //
-//  AppLovinBannerCustomEvent.m
+//  AppLovinInterstitialCustomEvent.m
 //
-#import "AppLovinBannerCustomEvent.h"
-#import "MPConstants.h"
-#import "MPError.h"
-#import "MPLogging.h"
-#import "MoPub.h"
+
+#import "AppLovinInterstitialCustomEvent.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPError.h"
+    #import "MPLogging.h"
+    #import "MoPub.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+// TODO: enable this import (and disabled code below) after MPError.h has been added to MoPubSDKFramework
+//    #import <MoPubSDKFramework/MPError.h>
+    #import <MoPubSDKFramework/MPLogging.h>
+    #import <MoPubSDKFramework/MoPub.h>
+#endif
 
 #if __has_include(<AppLovinSDK/AppLovinSDK.h>)
     #import <AppLovinSDK/AppLovinSDK.h>
 #else
-    #import "ALAdView.h"
+    #import "ALInterstitialAd.h"
 #endif
 
 // Convenience macro for checking if AppLovin SDK has support for zones
 #define HAS_ZONES_SUPPORT(_SDK) [_SDK.adService respondsToSelector: @selector(loadNextAdForZoneIdentifier:andNotify:)]
-#define EMPTY_ZONE @""
+#define DEFAULT_ZONE @""
 
-/**
- * The receiver object of the ALAdView's delegates. This is used to prevent a retain cycle between the ALAdView and AppLovinBannerCustomEvent.
- */
-@interface AppLovinMoPubBannerDelegate : NSObject<ALAdLoadDelegate, ALAdDisplayDelegate, ALAdViewEventDelegate>
-@property (nonatomic, weak) AppLovinBannerCustomEvent *parentCustomEvent;
-- (instancetype)initWithCustomEvent:(AppLovinBannerCustomEvent *)parentCustomEvent;
-@end
+@interface AppLovinInterstitialCustomEvent() <ALAdLoadDelegate, ALAdDisplayDelegate, ALAdVideoPlaybackDelegate>
 
-@interface AppLovinBannerCustomEvent()
 @property (nonatomic, strong) ALSdk *sdk;
-@property (nonatomic, strong) ALAdView *adView;
+@property (nonatomic, strong) ALInterstitialAd *interstitialAd;
+@property (nonatomic,   copy) NSString *zoneIdentifier; // The zone identifier this instance of the custom event is loading for
+
 @end
 
-@implementation AppLovinBannerCustomEvent
+@implementation AppLovinInterstitialCustomEvent
 static NSString *const kALMoPubMediationErrorDomain = @"com.applovin.sdk.mediation.mopub.errorDomain";
 
-static const CGFloat kALBannerHeightOffsetTolerance = 10.0f;
-static const CGFloat kALBannerStandardHeight = 50.0f;
-static const CGFloat kALLeaderHeightOffsetTolerance = 16.0f;
-static const CGFloat kALLeaderStandardHeight = 90.0f;
+// A dictionary of Zone -> Queue of `ALAd`s to be shared by instances of the custom event.
+// This prevents skipping of ads as this adapter will be re-created and preloaded
+// on every ad load regardless if ad was actually displayed or not.
+static NSMutableDictionary<NSString *, NSMutableArray<ALAd *> *> *ALGlobalInterstitialAds;
+static NSObject *ALGlobalInterstitialAdsLock;
 
-// A dictionary of Zone -> AdView to be shared by instances of the custom event.
-static NSMutableDictionary<NSString *, ALAdView *> *ALGlobalAdViews;
+#pragma mark - Class Initialization
 
 + (void)initialize
 {
     [super initialize];
-
-    ALGlobalAdViews = [NSMutableDictionary dictionary];
+    
+    ALGlobalInterstitialAds = [NSMutableDictionary dictionary];
+    ALGlobalInterstitialAdsLock = [[NSObject alloc] init];
 }
 
-#pragma mark - MPBannerCustomEvent Overridden Methods
+#pragma mark - MPInterstitialCustomEvent Overridden Methods
 
-- (void)requestAdWithSize:(CGSize)size customEventInfo:(NSDictionary *)info
+- (void)requestInterstitialWithCustomEventInfo:(NSDictionary *)info
 {
     // Collect and pass the user's consent from MoPub onto the AppLovin SDK
     if ([[MoPub sharedInstance] isGDPRApplicable] == MPBoolYes) {
@@ -58,121 +61,167 @@ static NSMutableDictionary<NSString *, ALAdView *> *ALGlobalAdViews;
         [ALPrivacySettings setHasUserConsent: canCollectPersonalInfo];
     }
     
-    [self log: @"Requesting AppLovin banner of size %@ with info: %@", NSStringFromCGSize(size), info];
+    [self log: @"Requesting AppLovin interstitial with info: %@", info];
     
-    // Convert requested size to AppLovin Ad Size
-    ALAdSize *adSize = [self appLovinAdSizeFromRequestedSize: size];
-    if ( adSize )
+    self.sdk = [self SDKFromCustomEventInfo: info];
+    [self.sdk setPluginVersion: @"MoPub-Certified-3.0.0"];
+    
+    // Zones support is available on AppLovin SDK 4.5.0 and higher
+    if ( HAS_ZONES_SUPPORT(self.sdk) && info[@"zone_id"] )
     {
-        self.sdk = [self SDKFromCustomEventInfo: info];
-        [self.sdk setPluginVersion: @"MoPub-Certified-3.0.0"];
-        
-        // Zones support is available on AppLovin SDK 4.5.0 and higher
-        NSString *zoneIdentifier = info[@"zone_id"];
-        if ( HAS_ZONES_SUPPORT(self.sdk) && zoneIdentifier.length > 0 )
-        {
-            self.adView = ALGlobalAdViews[zoneIdentifier];
-            if ( !self.adView )
-            {
-                self.adView = [self adViewWithAdSize: adSize zoneIdentifier: zoneIdentifier];
-                ALGlobalAdViews[zoneIdentifier] = self.adView;
-            }
-        }
-        else
-        {
-            self.adView = ALGlobalAdViews[EMPTY_ZONE];
-            if ( !self.adView )
-            {
-                self.adView = [[ALAdView alloc] initWithFrame: CGRectMake(0.0f, 0.0f, size.width, size.height)
-                                                         size: adSize
-                                                          sdk: self.sdk];
-                ALGlobalAdViews[EMPTY_ZONE] = self.adView;
-            }
-        }
-        
-        AppLovinMoPubBannerDelegate *delegate = [[AppLovinMoPubBannerDelegate alloc] initWithCustomEvent: self];
-        self.adView.adLoadDelegate = delegate;
-        self.adView.adDisplayDelegate = delegate;
-        
-        // As of iOS SDK >= 4.3.0, we added a delegate for banner events
-        if ( [self.adView respondsToSelector: @selector(setAdEventDelegate:)] )
-        {
-            self.adView.adEventDelegate = delegate;
-        }
-        
-        [self.adView loadNextAd];
+        self.zoneIdentifier = info[@"zone_id"];
     }
     else
     {
-        [self log: @"Failed to create an AppLovin banner with invalid size"];
-        
-        NSString *failureReason = [NSString stringWithFormat: @"Adaptor requested to display a banner with invalid size: %@.", NSStringFromCGSize(size)];
-        NSError *error = [NSError errorWithDomain: kALMoPubMediationErrorDomain
-                                             code: kALErrorCodeUnableToRenderAd
-                                         userInfo: @{NSLocalizedFailureReasonErrorKey : failureReason}];
-        
-        [self.delegate bannerCustomEvent: self didFailToLoadAdWithError: error];
+        self.zoneIdentifier = DEFAULT_ZONE;
+    }
+    
+    // Check if we already have a preloaded ad for the given zone
+    ALAd *preloadedAd = [[self class] dequeueAdForZoneIdentifier: self.zoneIdentifier];
+    if ( preloadedAd )
+    {
+        [self log: @"Found preloaded ad for zone: {%@}", self.zoneIdentifier];
+        [self adService: self.sdk.adService didLoadAd: preloadedAd];
+    }
+    // No ad currently preloaded
+    else
+    {
+        // If this is a default Zone, create the incentivized ad normally
+        if ( [DEFAULT_ZONE isEqualToString: self.zoneIdentifier] )
+        {
+            [self.sdk.adService loadNextAd: [ALAdSize sizeInterstitial] andNotify: self];
+        }
+        // Otherwise, use the Zones API
+        else
+        {
+            // Dynamically load an ad for a given zone without breaking backwards compatibility for publishers on older SDKs
+            [self.sdk.adService performSelector: @selector(loadNextAdForZoneIdentifier:andNotify:)
+                                     withObject: self.zoneIdentifier
+                                     withObject: self];
+        }
     }
 }
 
-- (BOOL)enableAutomaticImpressionAndClickTracking
+- (void)showInterstitialFromRootViewController:(UIViewController *)rootViewController
 {
-    return NO;
+    ALAd *preloadedAd = [[self class] dequeueAdForZoneIdentifier: self.zoneIdentifier];
+    if ( preloadedAd )
+    {
+        self.interstitialAd = [[ALInterstitialAd alloc] initWithSdk: self.sdk];
+        self.interstitialAd.adDisplayDelegate = self;
+        self.interstitialAd.adVideoPlaybackDelegate = self;
+        [self.interstitialAd showOver: rootViewController.view.window andRender: preloadedAd];
+    }
+    else
+    {
+        [self log: @"Failed to show an AppLovin interstitial before one was loaded"];
+        
+        NSError *error = [NSError errorWithDomain: kALMoPubMediationErrorDomain
+                                             code: kALErrorCodeUnableToRenderAd
+                                         userInfo: @{NSLocalizedFailureReasonErrorKey : @"Adaptor requested to display an interstitial before one was loaded"}];
+        
+        [self.delegate interstitialCustomEvent: self didFailToLoadAdWithError: error];
+    }
+}
+
+#pragma mark - Ad Load Delegate
+
+- (void)adService:(ALAdService *)adService didLoadAd:(ALAd *)ad
+{
+    [self log: @"Interstitial did load ad: %@", ad.adIdNumber];
+    
+    [[self class] enqueueAd: ad forZoneIdentifier: self.zoneIdentifier];
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.delegate interstitialCustomEvent: self didLoadAd: ad];
+    });
+}
+
+- (void)adService:(ALAdService *)adService didFailToLoadAdWithError:(int)code
+{
+    [self log: @"Interstitial failed to load with error: %d", code];
+    
+    NSError *error = [NSError errorWithDomain: kALMoPubMediationErrorDomain
+                                         code: [self toMoPubErrorCode: code]
+                                     userInfo: nil];
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.delegate interstitialCustomEvent: self didFailToLoadAdWithError: error];
+    });
+}
+
+#pragma mark - Ad Display Delegate
+
+- (void)ad:(ALAd *)ad wasDisplayedIn:(UIView *)view
+{
+    [self log: @"Interstitial displayed"];
+    
+    [self.delegate interstitialCustomEventWillAppear: self];
+    [self.delegate interstitialCustomEventDidAppear: self];
+}
+
+- (void)ad:(ALAd *)ad wasHiddenIn:(UIView *)view
+{
+    [self log: @"Interstitial dismissed"];
+    
+    [self.delegate interstitialCustomEventWillDisappear: self];
+    [self.delegate interstitialCustomEventDidDisappear: self];
+    
+    self.interstitialAd = nil;
+}
+
+- (void)ad:(ALAd *)ad wasClickedIn:(UIView *)view
+{
+    [self log: @"Interstitial clicked"];
+    
+    [self.delegate interstitialCustomEventDidReceiveTapEvent: self];
+    [self.delegate interstitialCustomEventWillLeaveApplication: self];
+}
+
+#pragma mark - Video Playback Delegate
+
+- (void)videoPlaybackBeganInAd:(ALAd *)ad
+{
+    [self log: @"Interstitial video playback began"];
+}
+
+- (void)videoPlaybackEndedInAd:(ALAd *)ad atPlaybackPercent:(NSNumber *)percentPlayed fullyWatched:(BOOL)wasFullyWatched
+{
+    [self log: @"Interstitial video playback ended at playback percent: %lu", percentPlayed.unsignedIntegerValue];
 }
 
 #pragma mark - Utility Methods
 
-/**
- * Dynamically create an instance of ALAdView with a given zone without breaking backwards compatibility for publishers on older SDKs.
- */
-- (ALAdView *)adViewWithAdSize:(ALAdSize *)adSize zoneIdentifier:(NSString *)zoneIdentifier
++ (alnullable ALAd *)dequeueAdForZoneIdentifier:(NSString *)zoneIdentifier
 {
-    ALAdView *adView = [[ALAdView alloc] initWithSdk: self.sdk size: adSize];
-    
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wundeclared-selector"
-    if ( [adView respondsToSelector: @selector(setZoneIdentifier:)] )
+    @synchronized ( ALGlobalInterstitialAdsLock )
     {
-        [adView performSelector: @selector(setZoneIdentifier:) withObject: zoneIdentifier];
+        ALAd *preloadedAd;
+        
+        NSMutableArray<ALAd *> *preloadedAds = ALGlobalInterstitialAds[zoneIdentifier];
+        if ( preloadedAds.count > 0 )
+        {
+            preloadedAd = preloadedAds[0];
+            [preloadedAds removeObjectAtIndex: 0];
+        }
+        
+        return preloadedAd;
     }
-#pragma clang diagnostic pop
-    
-    return adView;
 }
 
-- (ALAdSize *)appLovinAdSizeFromRequestedSize:(CGSize)size
++ (void)enqueueAd:(ALAd *)ad forZoneIdentifier:(NSString *)zoneIdentifier
 {
-    if ( CGSizeEqualToSize(size, MOPUB_BANNER_SIZE) )
+    @synchronized ( ALGlobalInterstitialAdsLock )
     {
-        return [ALAdSize sizeBanner];
-    }
-    else if ( CGSizeEqualToSize(size, MOPUB_MEDIUM_RECT_SIZE) )
-    {
-        return [ALAdSize sizeMRec];
-    }
-    else if ( CGSizeEqualToSize(size, MOPUB_LEADERBOARD_SIZE) )
-    {
-        return [ALAdSize sizeLeader];
-    }
-    // This is not a one of MoPub's predefined size
-    else
-    {
-        // Assume fluid width, and check for height with offset tolerance
-        
-        CGFloat bannerOffset = ABS(kALBannerStandardHeight - size.height);
-        CGFloat leaderOffset = ABS(kALLeaderStandardHeight - size.height);
-        
-        if ( bannerOffset <= kALBannerHeightOffsetTolerance )
+        NSMutableArray<ALAd *> *preloadedAds = ALGlobalInterstitialAds[zoneIdentifier];
+        if ( !preloadedAds )
         {
-            return [ALAdSize sizeBanner];
+            preloadedAds = [NSMutableArray array];
+            ALGlobalInterstitialAds[zoneIdentifier] = preloadedAds;
         }
-        else if ( leaderOffset <= kALLeaderHeightOffsetTolerance )
-        {
-            return [ALAdSize sizeLeader];
-        }
+        
+        [preloadedAds addObject: ad];
     }
-    
-    return nil;
 }
 
 - (void)log:(NSString *)format, ...
@@ -182,28 +231,28 @@ static NSMutableDictionary<NSString *, ALAdView *> *ALGlobalAdViews;
     NSString *message = [[NSString alloc] initWithFormat: format arguments: valist];
     va_end(valist);
     
-    MPLogDebug(@"AppLovinBannerCustomEvent : %@", message);
+    MPLogDebug(@"AppLovinInterstitialCustomEvent : %@", message);
 }
 
-- (MOPUBErrorCode)toMoPubErrorCode:(int)appLovinErrorCode
-{
-    if ( appLovinErrorCode == kALErrorCodeNoFill )
-    {
-        return MOPUBErrorAdapterHasNoInventory;
-    }
-    else if ( appLovinErrorCode == kALErrorCodeAdRequestNetworkTimeout )
-    {
-        return MOPUBErrorNetworkTimedOut;
-    }
-    else if ( appLovinErrorCode == kALErrorCodeInvalidResponse )
-    {
-        return MOPUBErrorServerError;
-    }
-    else
-    {
-        return MOPUBErrorUnknown;
-    }
-}
+//- (MOPUBErrorCode)toMoPubErrorCode:(int)appLovinErrorCode
+//{
+//    if ( appLovinErrorCode == kALErrorCodeNoFill )
+//    {
+//        return MOPUBErrorAdapterHasNoInventory;
+//    }
+//    else if ( appLovinErrorCode == kALErrorCodeAdRequestNetworkTimeout )
+//    {
+//        return MOPUBErrorNetworkTimedOut;
+//    }
+//    else if ( appLovinErrorCode == kALErrorCodeInvalidResponse )
+//    {
+//        return MOPUBErrorServerError;
+//    }
+//    else
+//    {
+//        return MOPUBErrorUnknown;
+//    }
+//}
 
 - (ALSdk *)SDKFromCustomEventInfo:(NSDictionary *)info
 {
@@ -216,105 +265,6 @@ static NSMutableDictionary<NSString *, ALAdView *> *ALGlobalAdViews;
     {
         return [ALSdk shared];
     }
-}
-
-@end
-
-@implementation AppLovinMoPubBannerDelegate
-
-#pragma mark - Initialization
-
-- (instancetype)initWithCustomEvent:(AppLovinBannerCustomEvent *)parentCustomEvent
-{
-    self = [super init];
-    if ( self )
-    {
-        self.parentCustomEvent = parentCustomEvent;
-    }
-    return self;
-}
-
-#pragma mark - Ad Load Delegate
-
-- (void)adService:(ALAdService *)adService didLoadAd:(ALAd *)ad
-{
-    // Ensure logic is ran on main queue
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.parentCustomEvent log: @"Banner did load ad: %@", ad.adIdNumber];
-        [self.parentCustomEvent.delegate bannerCustomEvent: self.parentCustomEvent didLoadAd: self.parentCustomEvent.adView];
-    });
-}
-
-- (void)adService:(ALAdService *)adService didFailToLoadAdWithError:(int)code
-{
-    // Ensure logic is ran on main queue
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.parentCustomEvent log: @"Banner failed to load with error: %d", code];
-        
-        NSError *error = [NSError errorWithDomain: kALMoPubMediationErrorDomain
-                                             code: [self.parentCustomEvent toMoPubErrorCode: code]
-                                         userInfo: nil];
-        [self.parentCustomEvent.delegate bannerCustomEvent: self.parentCustomEvent didFailToLoadAdWithError: error];
-    });
-}
-
-#pragma mark - Ad Display Delegate
-
-- (void)ad:(ALAd *)ad wasDisplayedIn:(UIView *)view
-{
-    [self.parentCustomEvent log: @"Banner displayed"];
-    
-    // `didDisplayAd` of this class would not be called by MoPub on AppLovin banner refresh if enabled.
-    // Only way to track impression of AppLovin refresh is via this callback.
-    [self.parentCustomEvent.delegate trackImpression];
-}
-
-- (void)ad:(ALAd *)ad wasHiddenIn:(UIView *)view
-{
-    [self.parentCustomEvent log: @"Banner dismissed"];
-}
-
-- (void)ad:(ALAd *)ad wasClickedIn:(UIView *)view
-{
-    [self.parentCustomEvent log: @"Banner clicked"];
-    
-    [self.parentCustomEvent.delegate trackClick];
-    [self.parentCustomEvent.delegate bannerCustomEventWillLeaveApplication: self.parentCustomEvent];
-}
-
-#pragma mark - Ad View Event Delegate
-
-- (void)ad:(ALAd *)ad didPresentFullscreenForAdView:(ALAdView *)adView
-{
-    [self.parentCustomEvent log: @"Banner presented fullscreen"];
-    [self.parentCustomEvent.delegate bannerCustomEventWillBeginAction: self.parentCustomEvent];
-}
-
-- (void)ad:(ALAd *)ad willDismissFullscreenForAdView:(ALAdView *)adView
-{
-    [self.parentCustomEvent log: @"Banner will dismiss fullscreen"];
-}
-
-- (void)ad:(ALAd *)ad didDismissFullscreenForAdView:(ALAdView *)adView
-{
-    [self.parentCustomEvent log: @"Banner did dismiss fullscreen"];
-    [self.parentCustomEvent.delegate bannerCustomEventDidFinishAction: self.parentCustomEvent];
-}
-
-- (void)ad:(ALAd *)ad willLeaveApplicationForAdView:(ALAdView *)adView
-{
-    // We will fire bannerCustomEventWillLeaveApplication:: in the ad:wasClickedIn: callback
-    [self.parentCustomEvent log: @"Banner left application"];
-}
-
-- (void)ad:(ALAd *)ad didFailToDisplayInAdView:(ALAdView *)adView withError:(ALAdViewDisplayErrorCode)code
-{
-    [self.parentCustomEvent log: @"Banner failed to display: %ld", code];
-    
-    NSError *error = [NSError errorWithDomain: kALMoPubMediationErrorDomain
-                                         code: [self.parentCustomEvent toMoPubErrorCode: code]
-                                     userInfo: @{NSLocalizedFailureReasonErrorKey : @"Adaptor failed to display banner"}];
-    [self.parentCustomEvent.delegate bannerCustomEvent: self.parentCustomEvent didFailToLoadAdWithError: error];
 }
 
 @end

--- a/AppLovin/AppLovinInterstitialCustomEvent.h
+++ b/AppLovin/AppLovinInterstitialCustomEvent.h
@@ -3,9 +3,11 @@
 //
 
 #if __has_include(<MoPub/MoPub.h>)
-    #import "MPInterstitialCustomEvent.h"
+    #import <MoPub/MoPub.h>
 #elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPInterstitialCustomEvent.h>
+    #import <MoPubSDKFramework/MoPub.h>
+#else
+    #import "MPInterstitialCustomEvent.h"
 #endif
 
 @interface AppLovinInterstitialCustomEvent : MPInterstitialCustomEvent

--- a/AppLovin/AppLovinInterstitialCustomEvent.h
+++ b/AppLovin/AppLovinInterstitialCustomEvent.h
@@ -2,7 +2,11 @@
 //  AppLovinInterstitialCustomEvent.h
 //
 
-#import "MPInterstitialCustomEvent.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPInterstitialCustomEvent.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPInterstitialCustomEvent.h>
+#endif
 
 @interface AppLovinInterstitialCustomEvent : MPInterstitialCustomEvent
 

--- a/AppLovin/AppLovinInterstitialCustomEvent.m
+++ b/AppLovin/AppLovinInterstitialCustomEvent.m
@@ -132,18 +132,18 @@ static NSObject *ALGlobalInterstitialAdsLock;
     });
 }
 
-//- (void)adService:(ALAdService *)adService didFailToLoadAdWithError:(int)code
-//{
-//    [self log: @"Interstitial failed to load with error: %d", code];
-//
-//    NSError *error = [NSError errorWithDomain: kALMoPubMediationErrorDomain
-//                                         code: [self toMoPubErrorCode: code]
-//                                     userInfo: nil];
-//
-//    dispatch_async(dispatch_get_main_queue(), ^{
-//        [self.delegate interstitialCustomEvent: self didFailToLoadAdWithError: error];
-//    });
-//}
+- (void)adService:(ALAdService *)adService didFailToLoadAdWithError:(int)code
+{
+    [self log: @"Interstitial failed to load with error: %d", code];
+
+    NSError *error = [NSError errorWithDomain: kALMoPubMediationErrorDomain
+                                         code: code // [self toMoPubErrorCode: code]
+                                     userInfo: nil];
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.delegate interstitialCustomEvent: self didFailToLoadAdWithError: error];
+    });
+}
 
 #pragma mark - Ad Display Delegate
 

--- a/AppLovin/AppLovinInterstitialCustomEvent.m
+++ b/AppLovin/AppLovinInterstitialCustomEvent.m
@@ -3,15 +3,10 @@
 //
 
 #import "AppLovinInterstitialCustomEvent.h"
-#if __has_include(<MoPub/MoPub.h>)
+#if __has_include("MoPub.h")
     #import "MPError.h"
     #import "MPLogging.h"
     #import "MoPub.h"
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-// TODO: enable this import (and disabled code below) after MPError.h has been added to MoPubSDKFramework
-//    #import <MoPubSDKFramework/MPError.h>
-    #import <MoPubSDKFramework/MPLogging.h>
-    #import <MoPubSDKFramework/MoPub.h>
 #endif
 
 #if __has_include(<AppLovinSDK/AppLovinSDK.h>)

--- a/AppLovin/AppLovinInterstitialCustomEvent.m
+++ b/AppLovin/AppLovinInterstitialCustomEvent.m
@@ -137,7 +137,7 @@ static NSObject *ALGlobalInterstitialAdsLock;
     [self log: @"Interstitial failed to load with error: %d", code];
 
     NSError *error = [NSError errorWithDomain: kALMoPubMediationErrorDomain
-                                         code: code // [self toMoPubErrorCode: code]
+                                         code: [self toMoPubErrorCode: code]
                                      userInfo: nil];
 
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -229,25 +229,25 @@ static NSObject *ALGlobalInterstitialAdsLock;
     MPLogDebug(@"AppLovinInterstitialCustomEvent : %@", message);
 }
 
-//- (MOPUBErrorCode)toMoPubErrorCode:(int)appLovinErrorCode
-//{
-//    if ( appLovinErrorCode == kALErrorCodeNoFill )
-//    {
-//        return MOPUBErrorAdapterHasNoInventory;
-//    }
-//    else if ( appLovinErrorCode == kALErrorCodeAdRequestNetworkTimeout )
-//    {
-//        return MOPUBErrorNetworkTimedOut;
-//    }
-//    else if ( appLovinErrorCode == kALErrorCodeInvalidResponse )
-//    {
-//        return MOPUBErrorServerError;
-//    }
-//    else
-//    {
-//        return MOPUBErrorUnknown;
-//    }
-//}
+- (MOPUBErrorCode)toMoPubErrorCode:(int)appLovinErrorCode
+{
+   if ( appLovinErrorCode == kALErrorCodeNoFill )
+   {
+       return MOPUBErrorAdapterHasNoInventory;
+   }
+   else if ( appLovinErrorCode == kALErrorCodeAdRequestNetworkTimeout )
+   {
+       return MOPUBErrorNetworkTimedOut;
+   }
+   else if ( appLovinErrorCode == kALErrorCodeInvalidResponse )
+   {
+       return MOPUBErrorServerError;
+   }
+   else
+   {
+       return MOPUBErrorUnknown;
+   }
+}
 
 - (ALSdk *)SDKFromCustomEventInfo:(NSDictionary *)info
 {

--- a/AppLovin/AppLovinInterstitialCustomEvent.m
+++ b/AppLovin/AppLovinInterstitialCustomEvent.m
@@ -3,9 +3,16 @@
 //
 
 #import "AppLovinInterstitialCustomEvent.h"
-#import "MPError.h"
-#import "MPLogging.h"
-#import "MoPub.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPError.h"
+    #import "MPLogging.h"
+    #import "MoPub.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+// TODO: enable this import (and disabled code below) after MPError.h has been added to MoPubSDKFramework
+//    #import <MoPubSDKFramework/MPError.h>
+    #import <MoPubSDKFramework/MPLogging.h>
+    #import <MoPubSDKFramework/MoPub.h>
+#endif
 
 #if __has_include(<AppLovinSDK/AppLovinSDK.h>)
     #import <AppLovinSDK/AppLovinSDK.h>
@@ -130,18 +137,18 @@ static NSObject *ALGlobalInterstitialAdsLock;
     });
 }
 
-- (void)adService:(ALAdService *)adService didFailToLoadAdWithError:(int)code
-{
-    [self log: @"Interstitial failed to load with error: %d", code];
-    
-    NSError *error = [NSError errorWithDomain: kALMoPubMediationErrorDomain
-                                         code: [self toMoPubErrorCode: code]
-                                     userInfo: nil];
-    
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.delegate interstitialCustomEvent: self didFailToLoadAdWithError: error];
-    });
-}
+//- (void)adService:(ALAdService *)adService didFailToLoadAdWithError:(int)code
+//{
+//    [self log: @"Interstitial failed to load with error: %d", code];
+//
+//    NSError *error = [NSError errorWithDomain: kALMoPubMediationErrorDomain
+//                                         code: [self toMoPubErrorCode: code]
+//                                     userInfo: nil];
+//
+//    dispatch_async(dispatch_get_main_queue(), ^{
+//        [self.delegate interstitialCustomEvent: self didFailToLoadAdWithError: error];
+//    });
+//}
 
 #pragma mark - Ad Display Delegate
 
@@ -227,25 +234,25 @@ static NSObject *ALGlobalInterstitialAdsLock;
     MPLogDebug(@"AppLovinInterstitialCustomEvent : %@", message);
 }
 
-- (MOPUBErrorCode)toMoPubErrorCode:(int)appLovinErrorCode
-{
-    if ( appLovinErrorCode == kALErrorCodeNoFill )
-    {
-        return MOPUBErrorAdapterHasNoInventory;
-    }
-    else if ( appLovinErrorCode == kALErrorCodeAdRequestNetworkTimeout )
-    {
-        return MOPUBErrorNetworkTimedOut;
-    }
-    else if ( appLovinErrorCode == kALErrorCodeInvalidResponse )
-    {
-        return MOPUBErrorServerError;
-    }
-    else
-    {
-        return MOPUBErrorUnknown;
-    }
-}
+//- (MOPUBErrorCode)toMoPubErrorCode:(int)appLovinErrorCode
+//{
+//    if ( appLovinErrorCode == kALErrorCodeNoFill )
+//    {
+//        return MOPUBErrorAdapterHasNoInventory;
+//    }
+//    else if ( appLovinErrorCode == kALErrorCodeAdRequestNetworkTimeout )
+//    {
+//        return MOPUBErrorNetworkTimedOut;
+//    }
+//    else if ( appLovinErrorCode == kALErrorCodeInvalidResponse )
+//    {
+//        return MOPUBErrorServerError;
+//    }
+//    else
+//    {
+//        return MOPUBErrorUnknown;
+//    }
+//}
 
 - (ALSdk *)SDKFromCustomEventInfo:(NSDictionary *)info
 {

--- a/AppLovin/AppLovinInterstitialCustomEvent.m
+++ b/AppLovin/AppLovinInterstitialCustomEvent.m
@@ -135,11 +135,11 @@ static NSObject *ALGlobalInterstitialAdsLock;
 - (void)adService:(ALAdService *)adService didFailToLoadAdWithError:(int)code
 {
     [self log: @"Interstitial failed to load with error: %d", code];
-
+    
     NSError *error = [NSError errorWithDomain: kALMoPubMediationErrorDomain
                                          code: [self toMoPubErrorCode: code]
                                      userInfo: nil];
-
+    
     dispatch_async(dispatch_get_main_queue(), ^{
         [self.delegate interstitialCustomEvent: self didFailToLoadAdWithError: error];
     });
@@ -231,22 +231,22 @@ static NSObject *ALGlobalInterstitialAdsLock;
 
 - (MOPUBErrorCode)toMoPubErrorCode:(int)appLovinErrorCode
 {
-   if ( appLovinErrorCode == kALErrorCodeNoFill )
-   {
-       return MOPUBErrorAdapterHasNoInventory;
-   }
-   else if ( appLovinErrorCode == kALErrorCodeAdRequestNetworkTimeout )
-   {
-       return MOPUBErrorNetworkTimedOut;
-   }
-   else if ( appLovinErrorCode == kALErrorCodeInvalidResponse )
-   {
-       return MOPUBErrorServerError;
-   }
-   else
-   {
-       return MOPUBErrorUnknown;
-   }
+    if ( appLovinErrorCode == kALErrorCodeNoFill )
+    {
+        return MOPUBErrorAdapterHasNoInventory;
+    }
+    else if ( appLovinErrorCode == kALErrorCodeAdRequestNetworkTimeout )
+    {
+        return MOPUBErrorNetworkTimedOut;
+    }
+    else if ( appLovinErrorCode == kALErrorCodeInvalidResponse )
+    {
+        return MOPUBErrorServerError;
+    }
+    else
+    {
+        return MOPUBErrorUnknown;
+    }
 }
 
 - (ALSdk *)SDKFromCustomEventInfo:(NSDictionary *)info

--- a/AppLovin/AppLovinRewardedVideoCustomEvent.h
+++ b/AppLovin/AppLovinRewardedVideoCustomEvent.h
@@ -2,7 +2,11 @@
 //  AppLovinRewardedVideoCustomEvent.h
 //
 
-#import "MPRewardedVideoCustomEvent.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPRewardedVideoCustomEvent.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPRewardedVideoCustomEvent.h>
+#endif
 
 @interface AppLovinRewardedVideoCustomEvent : MPRewardedVideoCustomEvent
 

--- a/AppLovin/AppLovinRewardedVideoCustomEvent.h
+++ b/AppLovin/AppLovinRewardedVideoCustomEvent.h
@@ -3,9 +3,11 @@
 //
 
 #if __has_include(<MoPub/MoPub.h>)
-    #import "MPRewardedVideoCustomEvent.h"
+    #import <MoPub/MoPub.h>
 #elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPRewardedVideoCustomEvent.h>
+    #import <MoPubSDKFramework/MoPub.h>
+#else
+   #import "MPRewardedVideoCustomEvent.h"
 #endif
 
 @interface AppLovinRewardedVideoCustomEvent : MPRewardedVideoCustomEvent

--- a/AppLovin/AppLovinRewardedVideoCustomEvent.m
+++ b/AppLovin/AppLovinRewardedVideoCustomEvent.m
@@ -264,25 +264,25 @@ static NSMutableDictionary<NSString *, ALIncentivizedInterstitialAd *> *ALGlobal
     MPLogDebug(@"AppLovinRewardedVideoCustomEvent: %@", message);
 }
 
-- (MOPUBErrorCode)toMoPubErrorCode:(int)appLovinErrorCode
-{
-    if ( appLovinErrorCode == kALErrorCodeNoFill )
-    {
-        return MOPUBErrorAdapterHasNoInventory;
-    }
-    else if ( appLovinErrorCode == kALErrorCodeAdRequestNetworkTimeout )
-    {
-        return MOPUBErrorNetworkTimedOut;
-    }
-    else if ( appLovinErrorCode == kALErrorCodeInvalidResponse )
-    {
-        return MOPUBErrorServerError;
-    }
-    else
-    {
-        return MOPUBErrorUnknown;
-    }
-}
+//- (MOPUBErrorCode)toMoPubErrorCode:(int)appLovinErrorCode
+//{
+//    if ( appLovinErrorCode == kALErrorCodeNoFill )
+//    {
+//        return MOPUBErrorAdapterHasNoInventory;
+//    }
+//    else if ( appLovinErrorCode == kALErrorCodeAdRequestNetworkTimeout )
+//    {
+//        return MOPUBErrorNetworkTimedOut;
+//    }
+//    else if ( appLovinErrorCode == kALErrorCodeInvalidResponse )
+//    {
+//        return MOPUBErrorServerError;
+//    }
+//    else
+//    {
+//        return MOPUBErrorUnknown;
+//    }
+//}
 
 - (ALSdk *)SDKFromCustomEventInfo:(NSDictionary *)info
 {

--- a/AppLovin/AppLovinRewardedVideoCustomEvent.m
+++ b/AppLovin/AppLovinRewardedVideoCustomEvent.m
@@ -3,10 +3,12 @@
 //
 
 #import "AppLovinRewardedVideoCustomEvent.h"
-#import "MPRewardedVideoReward.h"
-#import "MPError.h"
-#import "MPLogging.h"
-#import "MoPub.h"
+#if __has_include("MoPub.h")
+    #import "MPRewardedVideoReward.h"
+    #import "MPError.h"
+    #import "MPLogging.h"
+    #import "MoPub.h"
+#endif
 
 #if __has_include(<AppLovinSDK/AppLovinSDK.h>)
     #import <AppLovinSDK/AppLovinSDK.h>
@@ -140,7 +142,7 @@ static NSMutableDictionary<NSString *, ALIncentivizedInterstitialAd *> *ALGlobal
     [self log: @"Rewarded video failed to load with error: %d", code];
     
     NSError *error = [NSError errorWithDomain: kALMoPubMediationErrorDomain
-                                         code: [self toMoPubErrorCode: code]
+                                         code: code //[self toMoPubErrorCode: code]
                                      userInfo: nil];
     
     dispatch_async(dispatch_get_main_queue(), ^{

--- a/AppLovin/AppLovinRewardedVideoCustomEvent.m
+++ b/AppLovin/AppLovinRewardedVideoCustomEvent.m
@@ -142,7 +142,7 @@ static NSMutableDictionary<NSString *, ALIncentivizedInterstitialAd *> *ALGlobal
     [self log: @"Rewarded video failed to load with error: %d", code];
     
     NSError *error = [NSError errorWithDomain: kALMoPubMediationErrorDomain
-                                         code: code //[self toMoPubErrorCode: code]
+                                         code: [self toMoPubErrorCode: code]
                                      userInfo: nil];
     
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -264,25 +264,25 @@ static NSMutableDictionary<NSString *, ALIncentivizedInterstitialAd *> *ALGlobal
     MPLogDebug(@"AppLovinRewardedVideoCustomEvent: %@", message);
 }
 
-//- (MOPUBErrorCode)toMoPubErrorCode:(int)appLovinErrorCode
-//{
-//    if ( appLovinErrorCode == kALErrorCodeNoFill )
-//    {
-//        return MOPUBErrorAdapterHasNoInventory;
-//    }
-//    else if ( appLovinErrorCode == kALErrorCodeAdRequestNetworkTimeout )
-//    {
-//        return MOPUBErrorNetworkTimedOut;
-//    }
-//    else if ( appLovinErrorCode == kALErrorCodeInvalidResponse )
-//    {
-//        return MOPUBErrorServerError;
-//    }
-//    else
-//    {
-//        return MOPUBErrorUnknown;
-//    }
-//}
+- (MOPUBErrorCode)toMoPubErrorCode:(int)appLovinErrorCode
+{
+   if ( appLovinErrorCode == kALErrorCodeNoFill )
+   {
+       return MOPUBErrorAdapterHasNoInventory;
+   }
+   else if ( appLovinErrorCode == kALErrorCodeAdRequestNetworkTimeout )
+   {
+       return MOPUBErrorNetworkTimedOut;
+   }
+   else if ( appLovinErrorCode == kALErrorCodeInvalidResponse )
+   {
+       return MOPUBErrorServerError;
+   }
+   else
+   {
+       return MOPUBErrorUnknown;
+   }
+}
 
 - (ALSdk *)SDKFromCustomEventInfo:(NSDictionary *)info
 {

--- a/AppLovin/AppLovinRewardedVideoCustomEvent.m
+++ b/AppLovin/AppLovinRewardedVideoCustomEvent.m
@@ -266,22 +266,22 @@ static NSMutableDictionary<NSString *, ALIncentivizedInterstitialAd *> *ALGlobal
 
 - (MOPUBErrorCode)toMoPubErrorCode:(int)appLovinErrorCode
 {
-   if ( appLovinErrorCode == kALErrorCodeNoFill )
-   {
-       return MOPUBErrorAdapterHasNoInventory;
-   }
-   else if ( appLovinErrorCode == kALErrorCodeAdRequestNetworkTimeout )
-   {
-       return MOPUBErrorNetworkTimedOut;
-   }
-   else if ( appLovinErrorCode == kALErrorCodeInvalidResponse )
-   {
-       return MOPUBErrorServerError;
-   }
-   else
-   {
-       return MOPUBErrorUnknown;
-   }
+    if ( appLovinErrorCode == kALErrorCodeNoFill )
+    {
+        return MOPUBErrorAdapterHasNoInventory;
+    }
+    else if ( appLovinErrorCode == kALErrorCodeAdRequestNetworkTimeout )
+    {
+        return MOPUBErrorNetworkTimedOut;
+    }
+    else if ( appLovinErrorCode == kALErrorCodeInvalidResponse )
+    {
+        return MOPUBErrorServerError;
+    }
+    else
+    {
+        return MOPUBErrorUnknown;
+    }
 }
 
 - (ALSdk *)SDKFromCustomEventInfo:(NSDictionary *)info

--- a/Chartboost/ChartboostInterstitialCustomEvent.m
+++ b/Chartboost/ChartboostInterstitialCustomEvent.m
@@ -9,7 +9,7 @@
 #if __has_include(<MoPub/MoPub.h>)
     #import "MPLogging.h"
 #elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPLogging.h>
+    #import <MoPubSDKFramework/MoPub.h>
 #endif
 #import "MPChartboostRouter.h"
 #import <Chartboost/Chartboost.h>

--- a/Chartboost/ChartboostInterstitialCustomEvent.m
+++ b/Chartboost/ChartboostInterstitialCustomEvent.m
@@ -6,7 +6,11 @@
 //
 
 #import "ChartboostInterstitialCustomEvent.h"
-#import "MPLogging.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPLogging.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPLogging.h>
+#endif
 #import "MPChartboostRouter.h"
 #import <Chartboost/Chartboost.h>
 

--- a/Chartboost/ChartboostRewardedVideoCustomEvent.m
+++ b/Chartboost/ChartboostRewardedVideoCustomEvent.m
@@ -7,16 +7,11 @@
 
 #import "ChartboostRewardedVideoCustomEvent.h"
 #import "MPChartboostRouter.h"
-#if __has_include(<MoPub/MoPub.h>)
+#if __has_include("MoPub.h")
     #import "MPLogging.h"
     #import "MPRewardedVideoReward.h"
     #import "MPRewardedVideoError.h"
     #import "MPRewardedVideoCustomEvent+Caching.h"
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPLogging.h>
-    #import <MoPubSDKFramework/MPRewardedVideoReward.h>
-    #import <MoPubSDKFramework/MPRewardedVideoError.h>
-    #import <MoPubSDKFramework/MPRewardedVideoCustomEvent+Caching.h>
 #endif
 #import <Chartboost/Chartboost.h>
 

--- a/Chartboost/ChartboostRewardedVideoCustomEvent.m
+++ b/Chartboost/ChartboostRewardedVideoCustomEvent.m
@@ -7,11 +7,18 @@
 
 #import "ChartboostRewardedVideoCustomEvent.h"
 #import "MPChartboostRouter.h"
-#import "MPLogging.h"
-#import "MPRewardedVideoReward.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPLogging.h"
+    #import "MPRewardedVideoReward.h"
+    #import "MPRewardedVideoError.h"
+    #import "MPRewardedVideoCustomEvent+Caching.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPLogging.h>
+    #import <MoPubSDKFramework/MPRewardedVideoReward.h>
+    #import <MoPubSDKFramework/MPRewardedVideoError.h>
+    #import <MoPubSDKFramework/MPRewardedVideoCustomEvent+Caching.h>
+#endif
 #import <Chartboost/Chartboost.h>
-#import "MPRewardedVideoError.h"
-#import "MPRewardedVideoCustomEvent+Caching.h"
 
 @interface ChartboostRewardedVideoCustomEvent () <ChartboostDelegate>
 @end

--- a/Chartboost/MPChartboostRouter.m
+++ b/Chartboost/MPChartboostRouter.m
@@ -6,12 +6,9 @@
 //
 
 #import "MPChartboostRouter.h"
-#if __has_include(<MoPub/MoPub.h>)
+#if __has_include("MoPub.h")
     #import "MPLogging.h"
     #import "MoPub.h"
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPLogging.h>
-    #import <MoPubSDKFramework/MoPub.h>
 #endif
 #import "ChartboostRewardedVideoCustomEvent.h"
 #import "ChartboostInterstitialCustomEvent.h"

--- a/Chartboost/MPChartboostRouter.m
+++ b/Chartboost/MPChartboostRouter.m
@@ -6,10 +6,15 @@
 //
 
 #import "MPChartboostRouter.h"
-#import "MPLogging.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPLogging.h"
+    #import "MoPub.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPLogging.h>
+    #import <MoPubSDKFramework/MoPub.h>
+#endif
 #import "ChartboostRewardedVideoCustomEvent.h"
 #import "ChartboostInterstitialCustomEvent.h"
-#import "MoPub.h"
 
 @interface ChartboostRewardedVideoCustomEvent (ChartboostRouter) <ChartboostDelegate>
 @end

--- a/FacebookAudienceNetwork/FacebookBannerCustomEvent.m
+++ b/FacebookAudienceNetwork/FacebookBannerCustomEvent.m
@@ -8,7 +8,11 @@
 #import <FBAudienceNetwork/FBAudienceNetwork.h>
 #import "FacebookBannerCustomEvent.h"
 
-#import "MPLogging.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPLogging.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPLogging.h>
+#endif
 
 @interface FacebookBannerCustomEvent () <FBAdViewDelegate>
 

--- a/FacebookAudienceNetwork/FacebookBannerCustomEvent.m
+++ b/FacebookAudienceNetwork/FacebookBannerCustomEvent.m
@@ -8,10 +8,8 @@
 #import <FBAudienceNetwork/FBAudienceNetwork.h>
 #import "FacebookBannerCustomEvent.h"
 
-#if __has_include(<MoPub/MoPub.h>)
+#if __has_include("MoPub.h")
     #import "MPLogging.h"
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPLogging.h>
 #endif
 
 @interface FacebookBannerCustomEvent () <FBAdViewDelegate>

--- a/FacebookAudienceNetwork/FacebookInterstitialCustomEvent.m
+++ b/FacebookAudienceNetwork/FacebookInterstitialCustomEvent.m
@@ -8,13 +8,9 @@
 #import <FBAudienceNetwork/FBAudienceNetwork.h>
 #import "FacebookInterstitialCustomEvent.h"
 
-#if __has_include(<MoPub/MoPub.h>)
+#if __has_include("MoPub.h")
     #import "MPLogging.h"
     #import "MPRealTimeTimer.h"
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPLogging.h>
-// TODO: enable this import (and disabled code below) after MPRealTimeTimer.h has been added to MoPubSDKFramework
-//    #import <MoPubSDKFramework/MPRealTimeTimer.h>
 #endif
 
 //Timer to record the expiration interval
@@ -23,6 +19,7 @@
 @interface FacebookInterstitialCustomEvent () <FBInterstitialAdDelegate>
 
 @property (nonatomic, strong) FBInterstitialAd *fbInterstitialAd;
+// TODO: enable this and related code after MPRealTimeTimer.h has been added to MoPubSDKFramework
 //@property (nonatomic, strong) MPRealTimeTimer *expirationTimer;
 @property (nonatomic, assign) BOOL hasTrackedImpression;
 
@@ -80,36 +77,36 @@
 }
 
 #pragma mark FBInterstitialAdDelegate methods
-//
-//- (void)interstitialAdDidLoad:(FBInterstitialAd *)interstitialAd
-//{
-//    MPLogInfo(@"Facebook intersitital ad was loaded. Can present now");
-//    [self.delegate interstitialCustomEvent:self didLoadAd:interstitialAd];
-//
-//    // introduce timer for 1 hour as per caching logic introduced by FB
-//
-//    __weak __typeof__(self) weakSelf = self;
-//    self.expirationTimer = [[MPRealTimeTimer alloc] initWithInterval:FB_ADS_EXPIRATION_INTERVAL block:^(MPRealTimeTimer *timer){
-//        __strong __typeof__(weakSelf) strongSelf = weakSelf;
-//        if (strongSelf && !strongSelf.hasTrackedImpression) {
-//            [strongSelf.delegate interstitialCustomEventDidExpire:strongSelf];
-//            MPLogInfo(@"Facebook intersitital ad expired as per the audience network's caching policy");
-//            //Delete the cached objects
-//            strongSelf.fbInterstitialAd = nil;
-//        }
-//        [strongSelf.expirationTimer invalidate];
-//    }];
-//    [self.expirationTimer scheduleNow];
-//
-//}
-//
-//- (void)interstitialAdWillLogImpression:(FBInterstitialAd *)interstitialAd
-//{
-//    MPLogInfo(@"Facebook intersitital ad is logging impressions for interstitials");
-//    //set the tracker to true when the ad is shown on the screen. So that the timer is invalidated.
-//    _hasTrackedImpression = true;
-//    [self.expirationTimer invalidate];
-//}
+
+- (void)interstitialAdDidLoad:(FBInterstitialAd *)interstitialAd
+{
+    MPLogInfo(@"Facebook intersitital ad was loaded. Can present now");
+    [self.delegate interstitialCustomEvent:self didLoadAd:interstitialAd];
+
+    // introduce timer for 1 hour as per caching logic introduced by FB
+
+    //__weak __typeof__(self) weakSelf = self;
+    //self.expirationTimer = [[MPRealTimeTimer alloc] initWithInterval:FB_ADS_EXPIRATION_INTERVAL block:^(MPRealTimeTimer *timer){
+    //    __strong __typeof__(weakSelf) strongSelf = weakSelf;
+    //    if (strongSelf && !strongSelf.hasTrackedImpression) {
+    //        [strongSelf.delegate interstitialCustomEventDidExpire:strongSelf];
+    //        MPLogInfo(@"Facebook intersitital ad expired as per the audience network's caching policy");
+    //        //Delete the cached objects
+    //        strongSelf.fbInterstitialAd = nil;
+    //    }
+    //    [strongSelf.expirationTimer invalidate];
+    //}];
+    //[self.expirationTimer scheduleNow];
+
+}
+
+- (void)interstitialAdWillLogImpression:(FBInterstitialAd *)interstitialAd
+{
+    MPLogInfo(@"Facebook intersitital ad is logging impressions for interstitials");
+    //set the tracker to true when the ad is shown on the screen. So that the timer is invalidated.
+    _hasTrackedImpression = true;
+    //[self.expirationTimer invalidate];
+}
 
 - (void)interstitialAd:(FBInterstitialAd *)interstitialAd didFailWithError:(NSError *)error
 {

--- a/FacebookAudienceNetwork/FacebookInterstitialCustomEvent.m
+++ b/FacebookAudienceNetwork/FacebookInterstitialCustomEvent.m
@@ -8,8 +8,14 @@
 #import <FBAudienceNetwork/FBAudienceNetwork.h>
 #import "FacebookInterstitialCustomEvent.h"
 
-#import "MPLogging.h"
-#import "MPRealTimeTimer.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPLogging.h"
+    #import "MPRealTimeTimer.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPLogging.h>
+// TODO: enable this import (and disabled code below) after MPRealTimeTimer.h has been added to MoPubSDKFramework
+//    #import <MoPubSDKFramework/MPRealTimeTimer.h>
+#endif
 
 //Timer to record the expiration interval
 #define FB_ADS_EXPIRATION_INTERVAL  3600
@@ -17,7 +23,7 @@
 @interface FacebookInterstitialCustomEvent () <FBInterstitialAdDelegate>
 
 @property (nonatomic, strong) FBInterstitialAd *fbInterstitialAd;
-@property (nonatomic, strong) MPRealTimeTimer *expirationTimer;
+//@property (nonatomic, strong) MPRealTimeTimer *expirationTimer;
 @property (nonatomic, assign) BOOL hasTrackedImpression;
 
 @end
@@ -74,36 +80,36 @@
 }
 
 #pragma mark FBInterstitialAdDelegate methods
-
-- (void)interstitialAdDidLoad:(FBInterstitialAd *)interstitialAd
-{
-    MPLogInfo(@"Facebook intersitital ad was loaded. Can present now");
-    [self.delegate interstitialCustomEvent:self didLoadAd:interstitialAd];
-
-    // introduce timer for 1 hour as per caching logic introduced by FB
-
-    __weak __typeof__(self) weakSelf = self;
-    self.expirationTimer = [[MPRealTimeTimer alloc] initWithInterval:FB_ADS_EXPIRATION_INTERVAL block:^(MPRealTimeTimer *timer){
-        __strong __typeof__(weakSelf) strongSelf = weakSelf;
-        if (strongSelf && !strongSelf.hasTrackedImpression) {
-            [strongSelf.delegate interstitialCustomEventDidExpire:strongSelf];
-            MPLogInfo(@"Facebook intersitital ad expired as per the audience network's caching policy");
-            //Delete the cached objects
-            strongSelf.fbInterstitialAd = nil;
-        }
-        [strongSelf.expirationTimer invalidate];
-    }];
-    [self.expirationTimer scheduleNow];
-
-}
-
-- (void)interstitialAdWillLogImpression:(FBInterstitialAd *)interstitialAd
-{
-    MPLogInfo(@"Facebook intersitital ad is logging impressions for interstitials");
-    //set the tracker to true when the ad is shown on the screen. So that the timer is invalidated.
-    _hasTrackedImpression = true;
-    [self.expirationTimer invalidate];
-}
+//
+//- (void)interstitialAdDidLoad:(FBInterstitialAd *)interstitialAd
+//{
+//    MPLogInfo(@"Facebook intersitital ad was loaded. Can present now");
+//    [self.delegate interstitialCustomEvent:self didLoadAd:interstitialAd];
+//
+//    // introduce timer for 1 hour as per caching logic introduced by FB
+//
+//    __weak __typeof__(self) weakSelf = self;
+//    self.expirationTimer = [[MPRealTimeTimer alloc] initWithInterval:FB_ADS_EXPIRATION_INTERVAL block:^(MPRealTimeTimer *timer){
+//        __strong __typeof__(weakSelf) strongSelf = weakSelf;
+//        if (strongSelf && !strongSelf.hasTrackedImpression) {
+//            [strongSelf.delegate interstitialCustomEventDidExpire:strongSelf];
+//            MPLogInfo(@"Facebook intersitital ad expired as per the audience network's caching policy");
+//            //Delete the cached objects
+//            strongSelf.fbInterstitialAd = nil;
+//        }
+//        [strongSelf.expirationTimer invalidate];
+//    }];
+//    [self.expirationTimer scheduleNow];
+//
+//}
+//
+//- (void)interstitialAdWillLogImpression:(FBInterstitialAd *)interstitialAd
+//{
+//    MPLogInfo(@"Facebook intersitital ad is logging impressions for interstitials");
+//    //set the tracker to true when the ad is shown on the screen. So that the timer is invalidated.
+//    _hasTrackedImpression = true;
+//    [self.expirationTimer invalidate];
+//}
 
 - (void)interstitialAd:(FBInterstitialAd *)interstitialAd didFailWithError:(NSError *)error
 {

--- a/FacebookAudienceNetwork/FacebookInterstitialCustomEvent.m
+++ b/FacebookAudienceNetwork/FacebookInterstitialCustomEvent.m
@@ -19,8 +19,7 @@
 @interface FacebookInterstitialCustomEvent () <FBInterstitialAdDelegate>
 
 @property (nonatomic, strong) FBInterstitialAd *fbInterstitialAd;
-// TODO: enable this and related code after MPRealTimeTimer.h has been added to MoPubSDKFramework
-//@property (nonatomic, strong) MPRealTimeTimer *expirationTimer;
+@property (nonatomic, strong) MPRealTimeTimer *expirationTimer;
 @property (nonatomic, assign) BOOL hasTrackedImpression;
 
 @end
@@ -85,18 +84,18 @@
 
     // introduce timer for 1 hour as per caching logic introduced by FB
 
-    //__weak __typeof__(self) weakSelf = self;
-    //self.expirationTimer = [[MPRealTimeTimer alloc] initWithInterval:FB_ADS_EXPIRATION_INTERVAL block:^(MPRealTimeTimer *timer){
-    //    __strong __typeof__(weakSelf) strongSelf = weakSelf;
-    //    if (strongSelf && !strongSelf.hasTrackedImpression) {
-    //        [strongSelf.delegate interstitialCustomEventDidExpire:strongSelf];
-    //        MPLogInfo(@"Facebook intersitital ad expired as per the audience network's caching policy");
-    //        //Delete the cached objects
-    //        strongSelf.fbInterstitialAd = nil;
-    //    }
-    //    [strongSelf.expirationTimer invalidate];
-    //}];
-    //[self.expirationTimer scheduleNow];
+    __weak __typeof__(self) weakSelf = self;
+    self.expirationTimer = [[MPRealTimeTimer alloc] initWithInterval:FB_ADS_EXPIRATION_INTERVAL block:^(MPRealTimeTimer *timer){
+       __strong __typeof__(weakSelf) strongSelf = weakSelf;
+       if (strongSelf && !strongSelf.hasTrackedImpression) {
+           [strongSelf.delegate interstitialCustomEventDidExpire:strongSelf];
+           MPLogInfo(@"Facebook intersitital ad expired as per the audience network's caching policy");
+           //Delete the cached objects
+           strongSelf.fbInterstitialAd = nil;
+       }
+       [strongSelf.expirationTimer invalidate];
+    }];
+    [self.expirationTimer scheduleNow];
 
 }
 
@@ -105,7 +104,7 @@
     MPLogInfo(@"Facebook intersitital ad is logging impressions for interstitials");
     //set the tracker to true when the ad is shown on the screen. So that the timer is invalidated.
     _hasTrackedImpression = true;
-    //[self.expirationTimer invalidate];
+    [self.expirationTimer invalidate];
 }
 
 - (void)interstitialAd:(FBInterstitialAd *)interstitialAd didFailWithError:(NSError *)error

--- a/FacebookAudienceNetwork/FacebookInterstitialCustomEvent.m
+++ b/FacebookAudienceNetwork/FacebookInterstitialCustomEvent.m
@@ -86,14 +86,14 @@
 
     __weak __typeof__(self) weakSelf = self;
     self.expirationTimer = [[MPRealTimeTimer alloc] initWithInterval:FB_ADS_EXPIRATION_INTERVAL block:^(MPRealTimeTimer *timer){
-       __strong __typeof__(weakSelf) strongSelf = weakSelf;
-       if (strongSelf && !strongSelf.hasTrackedImpression) {
-           [strongSelf.delegate interstitialCustomEventDidExpire:strongSelf];
-           MPLogInfo(@"Facebook intersitital ad expired as per the audience network's caching policy");
-           //Delete the cached objects
-           strongSelf.fbInterstitialAd = nil;
-       }
-       [strongSelf.expirationTimer invalidate];
+        __strong __typeof__(weakSelf) strongSelf = weakSelf;
+        if (strongSelf && !strongSelf.hasTrackedImpression) {
+            [strongSelf.delegate interstitialCustomEventDidExpire:strongSelf];
+            MPLogInfo(@"Facebook intersitital ad expired as per the audience network's caching policy");
+            //Delete the cached objects
+            strongSelf.fbInterstitialAd = nil;
+        }
+        [strongSelf.expirationTimer invalidate];
     }];
     [self.expirationTimer scheduleNow];
 

--- a/FacebookAudienceNetwork/FacebookNativeAdAdapter.m
+++ b/FacebookAudienceNetwork/FacebookNativeAdAdapter.m
@@ -7,9 +7,15 @@
 
 #import <FBAudienceNetwork/FBAudienceNetwork.h>
 #import "FacebookNativeAdAdapter.h"
-#import "MPNativeAdConstants.h"
-#import "MPNativeAdError.h"
-#import "MPLogging.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPNativeAdConstants.h"
+    #import "MPNativeAdError.h"
+    #import "MPLogging.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPNativeAdConstants.h>
+    #import <MoPubSDKFramework/MPNativeAdError.h>
+    #import <MoPubSDKFramework/MPLogging.h>
+#endif
 
 NSString *const kFBVideoAdsEnabledKey = @"video_enabled";
 

--- a/FacebookAudienceNetwork/FacebookNativeAdAdapter.m
+++ b/FacebookAudienceNetwork/FacebookNativeAdAdapter.m
@@ -7,14 +7,10 @@
 
 #import <FBAudienceNetwork/FBAudienceNetwork.h>
 #import "FacebookNativeAdAdapter.h"
-#if __has_include(<MoPub/MoPub.h>)
+#if __has_include("MoPub.h")
     #import "MPNativeAdConstants.h"
     #import "MPNativeAdError.h"
     #import "MPLogging.h"
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPNativeAdConstants.h>
-    #import <MoPubSDKFramework/MPNativeAdError.h>
-    #import <MoPubSDKFramework/MPLogging.h>
 #endif
 
 NSString *const kFBVideoAdsEnabledKey = @"video_enabled";

--- a/FacebookAudienceNetwork/FacebookNativeCustomEvent.m
+++ b/FacebookAudienceNetwork/FacebookNativeCustomEvent.m
@@ -7,16 +7,11 @@
 #import <FBAudienceNetwork/FBAudienceNetwork.h>
 #import "FacebookNativeCustomEvent.h"
 #import "FacebookNativeAdAdapter.h"
-#if __has_include(<MoPub/MoPub.h>)
+#if __has_include("MoPub.h")
     #import "MPNativeAd.h"
     #import "MPLogging.h"
     #import "MPNativeAdError.h"
     #import "MPNativeAdConstants.h"
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPNativeAd.h>
-    #import <MoPubSDKFramework/MPLogging.h>
-    #import <MoPubSDKFramework/MPNativeAdError.h>
-    #import <MoPubSDKFramework/MPNativeAdConstants.h>
 #endif
 
 static const NSInteger FacebookNoFillErrorCode = 1001;

--- a/FacebookAudienceNetwork/FacebookNativeCustomEvent.m
+++ b/FacebookAudienceNetwork/FacebookNativeCustomEvent.m
@@ -7,10 +7,17 @@
 #import <FBAudienceNetwork/FBAudienceNetwork.h>
 #import "FacebookNativeCustomEvent.h"
 #import "FacebookNativeAdAdapter.h"
-#import "MPNativeAd.h"
-#import "MPNativeAdError.h"
-#import "MPLogging.h"
-#import "MPNativeAdConstants.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPNativeAd.h"
+    #import "MPLogging.h"
+    #import "MPNativeAdError.h"
+    #import "MPNativeAdConstants.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPNativeAd.h>
+    #import <MoPubSDKFramework/MPLogging.h>
+    #import <MoPubSDKFramework/MPNativeAdError.h>
+    #import <MoPubSDKFramework/MPNativeAdConstants.h>
+#endif
 
 static const NSInteger FacebookNoFillErrorCode = 1001;
 static BOOL gVideoEnabled = NO;

--- a/FacebookAudienceNetwork/FacebookRewardedVideoCustomEvent.m
+++ b/FacebookAudienceNetwork/FacebookRewardedVideoCustomEvent.m
@@ -10,7 +10,6 @@
     #import "MPLogging.h"
     #import "MoPub.h"
     #import "MPRewardedVideoReward.h"
-    #import "MPRewardedVideoReward.h"
     #import "MPRealTimeTimer.h"
 #endif
 
@@ -116,17 +115,17 @@
 {
     MPLogInfo(@"Facebook rewarded video ad was loaded. Can present now.");
     [self.delegate rewardedVideoDidLoadAdForCustomEvent:self ];
-
+    
     // introduce timer for 1 hour as per caching logic introduced by FB
     __weak __typeof__(self) weakSelf = self;
     self.expirationTimer = [[MPRealTimeTimer alloc] initWithInterval:FB_ADS_EXPIRATION_INTERVAL block:^(MPRealTimeTimer *timer){
-       __strong __typeof__(weakSelf) strongSelf = weakSelf;
-       if (strongSelf && !strongSelf.hasTrackedImpression) {
-           [strongSelf.delegate rewardedVideoDidExpireForCustomEvent:strongSelf];
-           MPLogInfo(@"Facebook Rewarded Video ad expired as per the audience network's caching policy");
-           strongSelf.fbRewardedVideoAd = nil;
-       }
-       [strongSelf.expirationTimer invalidate];
+        __strong __typeof__(weakSelf) strongSelf = weakSelf;
+        if (strongSelf && !strongSelf.hasTrackedImpression) {
+            [strongSelf.delegate rewardedVideoDidExpireForCustomEvent:strongSelf];
+            MPLogInfo(@"Facebook Rewarded Video ad expired as per the audience network's caching policy");
+            strongSelf.fbRewardedVideoAd = nil;
+        }
+        [strongSelf.expirationTimer invalidate];
     }];
     [self.expirationTimer scheduleNow];
 }
@@ -205,7 +204,7 @@
     MPLogInfo(@"Facebook rewarded video has started playing and hence logging impression");
     //set the tracker to true when the ad is shown on the screen. So that the timer is invalidated.
     _hasTrackedImpression = true;
-   [self.expirationTimer invalidate];
+    [self.expirationTimer invalidate];
 }
 
 @end

--- a/FacebookAudienceNetwork/FacebookRewardedVideoCustomEvent.m
+++ b/FacebookAudienceNetwork/FacebookRewardedVideoCustomEvent.m
@@ -20,8 +20,7 @@
 @interface FacebookRewardedVideoCustomEvent () <FBRewardedVideoAdDelegate>
 
 @property (nonatomic, strong) FBRewardedVideoAd *fbRewardedVideoAd;
-// TODO: enable this related code below after MPRealTimeTimer.h has been added to MoPubSDKFramework
-//@property (nonatomic, strong) MPRealTimeTimer *expirationTimer;
+@property (nonatomic, strong) MPRealTimeTimer *expirationTimer;
 @property (nonatomic, assign) BOOL hasTrackedImpression;
 
 @end
@@ -119,17 +118,17 @@
     [self.delegate rewardedVideoDidLoadAdForCustomEvent:self ];
 
     // introduce timer for 1 hour as per caching logic introduced by FB
-    //__weak __typeof__(self) weakSelf = self;
-    //self.expirationTimer = [[MPRealTimeTimer alloc] initWithInterval:FB_ADS_EXPIRATION_INTERVAL block:^(MPRealTimeTimer *timer){
-    //    __strong __typeof__(weakSelf) strongSelf = weakSelf;
-    //    if (strongSelf && !strongSelf.hasTrackedImpression) {
-    //        [strongSelf.delegate rewardedVideoDidExpireForCustomEvent:strongSelf];
-    //        MPLogInfo(@"Facebook Rewarded Video ad expired as per the audience network's caching policy");
-    //        strongSelf.fbRewardedVideoAd = nil;
-    //    }
-    //    [strongSelf.expirationTimer invalidate];
-    //}];
-    //[self.expirationTimer scheduleNow];
+    __weak __typeof__(self) weakSelf = self;
+    self.expirationTimer = [[MPRealTimeTimer alloc] initWithInterval:FB_ADS_EXPIRATION_INTERVAL block:^(MPRealTimeTimer *timer){
+       __strong __typeof__(weakSelf) strongSelf = weakSelf;
+       if (strongSelf && !strongSelf.hasTrackedImpression) {
+           [strongSelf.delegate rewardedVideoDidExpireForCustomEvent:strongSelf];
+           MPLogInfo(@"Facebook Rewarded Video ad expired as per the audience network's caching policy");
+           strongSelf.fbRewardedVideoAd = nil;
+       }
+       [strongSelf.expirationTimer invalidate];
+    }];
+    [self.expirationTimer scheduleNow];
 }
 
 /*!
@@ -206,7 +205,7 @@
     MPLogInfo(@"Facebook rewarded video has started playing and hence logging impression");
     //set the tracker to true when the ad is shown on the screen. So that the timer is invalidated.
     _hasTrackedImpression = true;
-//    [self.expirationTimer invalidate];
+   [self.expirationTimer invalidate];
 }
 
 @end

--- a/FacebookAudienceNetwork/FacebookRewardedVideoCustomEvent.m
+++ b/FacebookAudienceNetwork/FacebookRewardedVideoCustomEvent.m
@@ -6,19 +6,12 @@
 #import <FBAudienceNetwork/FBAudienceNetwork.h>
 #import "FacebookRewardedVideoCustomEvent.h"
 
-#if __has_include(<MoPub/MoPub.h>)
+#if __has_include("MoPub.h")
     #import "MPLogging.h"
     #import "MoPub.h"
     #import "MPRewardedVideoReward.h"
     #import "MPRewardedVideoReward.h"
     #import "MPRealTimeTimer.h"
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPLogging.h>
-    #import <MoPubSDKFramework/MoPub.h>
-    #import <MoPubSDKFramework/MPRewardedVideoReward.h>
-    #import <MoPubSDKFramework/MPRewardedVideoReward.h>
-// TODO: enable this import (and disabled code below) after MPRealTimeTimer.h has been added to MoPubSDKFramework
-//    #import <MoPubSDKFramework/MPRealTimeTimer.h>
 #endif
 
 //Timer to record the expiration interval
@@ -27,6 +20,7 @@
 @interface FacebookRewardedVideoCustomEvent () <FBRewardedVideoAdDelegate>
 
 @property (nonatomic, strong) FBRewardedVideoAd *fbRewardedVideoAd;
+// TODO: enable this related code below after MPRealTimeTimer.h has been added to MoPubSDKFramework
 //@property (nonatomic, strong) MPRealTimeTimer *expirationTimer;
 @property (nonatomic, assign) BOOL hasTrackedImpression;
 
@@ -119,24 +113,24 @@
  
  @param rewardedVideoAd An FBRewardedVideoAd object sending the message.
  */
-//- (void)rewardedVideoAdDidLoad:(FBRewardedVideoAd *)rewardedVideoAd
-//{
-//    MPLogInfo(@"Facebook rewarded video ad was loaded. Can present now.");
-//    [self.delegate rewardedVideoDidLoadAdForCustomEvent:self ];
-//
-//    // introduce timer for 1 hour as per caching logic introduced by FB
-//    __weak __typeof__(self) weakSelf = self;
-//    self.expirationTimer = [[MPRealTimeTimer alloc] initWithInterval:FB_ADS_EXPIRATION_INTERVAL block:^(MPRealTimeTimer *timer){
-//        __strong __typeof__(weakSelf) strongSelf = weakSelf;
-//        if (strongSelf && !strongSelf.hasTrackedImpression) {
-//            [strongSelf.delegate rewardedVideoDidExpireForCustomEvent:strongSelf];
-//            MPLogInfo(@"Facebook Rewarded Video ad expired as per the audience network's caching policy");
-//            strongSelf.fbRewardedVideoAd = nil;
-//        }
-//        [strongSelf.expirationTimer invalidate];
-//    }];
-//    [self.expirationTimer scheduleNow];
-//}
+- (void)rewardedVideoAdDidLoad:(FBRewardedVideoAd *)rewardedVideoAd
+{
+    MPLogInfo(@"Facebook rewarded video ad was loaded. Can present now.");
+    [self.delegate rewardedVideoDidLoadAdForCustomEvent:self ];
+
+    // introduce timer for 1 hour as per caching logic introduced by FB
+    //__weak __typeof__(self) weakSelf = self;
+    //self.expirationTimer = [[MPRealTimeTimer alloc] initWithInterval:FB_ADS_EXPIRATION_INTERVAL block:^(MPRealTimeTimer *timer){
+    //    __strong __typeof__(weakSelf) strongSelf = weakSelf;
+    //    if (strongSelf && !strongSelf.hasTrackedImpression) {
+    //        [strongSelf.delegate rewardedVideoDidExpireForCustomEvent:strongSelf];
+    //        MPLogInfo(@"Facebook Rewarded Video ad expired as per the audience network's caching policy");
+    //        strongSelf.fbRewardedVideoAd = nil;
+    //    }
+    //    [strongSelf.expirationTimer invalidate];
+    //}];
+    //[self.expirationTimer scheduleNow];
+}
 
 /*!
  @method

--- a/FacebookAudienceNetwork/FacebookRewardedVideoCustomEvent.m
+++ b/FacebookAudienceNetwork/FacebookRewardedVideoCustomEvent.m
@@ -6,10 +6,20 @@
 #import <FBAudienceNetwork/FBAudienceNetwork.h>
 #import "FacebookRewardedVideoCustomEvent.h"
 
-#import "MPLogging.h"
-#import "MoPub.h"
-#import "MPRewardedVideoReward.h"
-#import "MPRealTimeTimer.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPLogging.h"
+    #import "MoPub.h"
+    #import "MPRewardedVideoReward.h"
+    #import "MPRewardedVideoReward.h"
+    #import "MPRealTimeTimer.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPLogging.h>
+    #import <MoPubSDKFramework/MoPub.h>
+    #import <MoPubSDKFramework/MPRewardedVideoReward.h>
+    #import <MoPubSDKFramework/MPRewardedVideoReward.h>
+// TODO: enable this import (and disabled code below) after MPRealTimeTimer.h has been added to MoPubSDKFramework
+//    #import <MoPubSDKFramework/MPRealTimeTimer.h>
+#endif
 
 //Timer to record the expiration interval
 #define FB_ADS_EXPIRATION_INTERVAL  3600
@@ -17,7 +27,7 @@
 @interface FacebookRewardedVideoCustomEvent () <FBRewardedVideoAdDelegate>
 
 @property (nonatomic, strong) FBRewardedVideoAd *fbRewardedVideoAd;
-@property (nonatomic, strong) MPRealTimeTimer *expirationTimer;
+//@property (nonatomic, strong) MPRealTimeTimer *expirationTimer;
 @property (nonatomic, assign) BOOL hasTrackedImpression;
 
 @end
@@ -109,24 +119,24 @@
  
  @param rewardedVideoAd An FBRewardedVideoAd object sending the message.
  */
-- (void)rewardedVideoAdDidLoad:(FBRewardedVideoAd *)rewardedVideoAd
-{
-    MPLogInfo(@"Facebook rewarded video ad was loaded. Can present now.");
-    [self.delegate rewardedVideoDidLoadAdForCustomEvent:self ];
-    
-    // introduce timer for 1 hour as per caching logic introduced by FB
-    __weak __typeof__(self) weakSelf = self;
-    self.expirationTimer = [[MPRealTimeTimer alloc] initWithInterval:FB_ADS_EXPIRATION_INTERVAL block:^(MPRealTimeTimer *timer){
-        __strong __typeof__(weakSelf) strongSelf = weakSelf;
-        if (strongSelf && !strongSelf.hasTrackedImpression) {
-            [strongSelf.delegate rewardedVideoDidExpireForCustomEvent:strongSelf];
-            MPLogInfo(@"Facebook Rewarded Video ad expired as per the audience network's caching policy");
-            strongSelf.fbRewardedVideoAd = nil;
-        }
-        [strongSelf.expirationTimer invalidate];
-    }];
-    [self.expirationTimer scheduleNow];
-}
+//- (void)rewardedVideoAdDidLoad:(FBRewardedVideoAd *)rewardedVideoAd
+//{
+//    MPLogInfo(@"Facebook rewarded video ad was loaded. Can present now.");
+//    [self.delegate rewardedVideoDidLoadAdForCustomEvent:self ];
+//
+//    // introduce timer for 1 hour as per caching logic introduced by FB
+//    __weak __typeof__(self) weakSelf = self;
+//    self.expirationTimer = [[MPRealTimeTimer alloc] initWithInterval:FB_ADS_EXPIRATION_INTERVAL block:^(MPRealTimeTimer *timer){
+//        __strong __typeof__(weakSelf) strongSelf = weakSelf;
+//        if (strongSelf && !strongSelf.hasTrackedImpression) {
+//            [strongSelf.delegate rewardedVideoDidExpireForCustomEvent:strongSelf];
+//            MPLogInfo(@"Facebook Rewarded Video ad expired as per the audience network's caching policy");
+//            strongSelf.fbRewardedVideoAd = nil;
+//        }
+//        [strongSelf.expirationTimer invalidate];
+//    }];
+//    [self.expirationTimer scheduleNow];
+//}
 
 /*!
  @method
@@ -202,7 +212,7 @@
     MPLogInfo(@"Facebook rewarded video has started playing and hence logging impression");
     //set the tracker to true when the ad is shown on the screen. So that the timer is invalidated.
     _hasTrackedImpression = true;
-    [self.expirationTimer invalidate];
+//    [self.expirationTimer invalidate];
 }
 
 @end

--- a/Flurry/FlurryInterstitialCustomEvent.h
+++ b/Flurry/FlurryInterstitialCustomEvent.h
@@ -6,7 +6,14 @@
 //  Copyright (c) 2015 Yahoo, Inc. All rights reserved.
 //
 
-#import "FlurryAdInterstitialDelegate.h"
+#if __has_include(<Flurry_iOS_SDK/FlurryAdInterstitial.h>)
+    #import <Flurry_iOS_SDK/FlurryAdInterstitial.h>
+    #import <Flurry_iOS_SDK/FlurryAdInterstitialDelegate.h>
+#else
+    #import "FlurryAdInterstitial.h"
+    #import "FlurryAdInterstitialDelegate.h"
+#endif
+
 #if __has_include(<MoPub/MoPub.h>)
     #import <MoPub/MoPub.h>
 #elif __has_include(<MoPubSDKFramework/MoPub.h>)

--- a/Flurry/FlurryInterstitialCustomEvent.m
+++ b/Flurry/FlurryInterstitialCustomEvent.m
@@ -7,11 +7,11 @@
 //
 
 #import "FlurryInterstitialCustomEvent.h"
-#import "FlurryAdInterstitial.h"
-#import "FlurryAdError.h"
 #import "FlurryMPConfig.h"
 
-#import "MPLogging.h"
+#if __has_include("MoPub.h")
+    #import "MPLogging.h"
+#endif
 
 @interface  FlurryInterstitialCustomEvent()
 

--- a/Flurry/FlurryMPConfig.h
+++ b/Flurry/FlurryMPConfig.h
@@ -7,7 +7,14 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "Flurry.h"
+
+#if __has_include(<Flurry_iOS_SDK/Flurry.h>)
+    #import <Flurry_iOS_SDK/Flurry.h>
+    #import <Flurry_iOS_SDK/FlurryAdError.h>
+#else
+    #import "Flurry.h"
+    #import "FlurryAdError.h"
+#endif
 
 #define FlurryMediationOrigin @"Flurry_Mopub_iOS"
 #define FlurryAdapterVersion @"7.6.4"

--- a/Flurry/FlurryNativeAdAdapter.h
+++ b/Flurry/FlurryNativeAdAdapter.h
@@ -6,8 +6,21 @@
 //  Copyright (c) 2015 Yahoo, Inc. All rights reserved.
 //
 
-#import "MPNativeAdAdapter.h"
-#import "FlurryAdNative.h"
+#if __has_include(<Flurry_iOS_SDK/FlurryAdNative.h>)
+    #import <Flurry_iOS_SDK/FlurryAdNative.h>
+    #import <Flurry_iOS_SDK/FlurryAdNativeDelegate.h>
+#else
+    #import "FlurryAdNative.h"
+    #import "FlurryAdNativeDelegate.h"
+#endif
+
+#if __has_include(<MoPub/MoPub.h>)
+    #import <MoPub/MoPub.h>
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MoPub.h>
+#else
+    #import "MPNativeAdAdapter.h"
+#endif
 
 @interface FlurryNativeAdAdapter : NSObject <MPNativeAdAdapter>
 

--- a/Flurry/FlurryNativeAdAdapter.m
+++ b/Flurry/FlurryNativeAdAdapter.m
@@ -7,10 +7,11 @@
 //
 
 #import "FlurryNativeAdAdapter.h"
-#import "FlurryAdNativeDelegate.h"
-#import "MPNativeAdConstants.h"
-#import "MPNativeAdError.h"
-#import "MPLogging.h"
+#if __has_include("MoPub.h")
+    #import "MPNativeAdConstants.h"
+    #import "MPNativeAdError.h"
+    #import "MPLogging.h"
+#endif
 
 @interface FlurryNativeAdAdapter() <FlurryAdNativeDelegate>
 

--- a/Flurry/FlurryNativeCustomEvent.m
+++ b/Flurry/FlurryNativeCustomEvent.m
@@ -7,11 +7,12 @@
 //
 
 #import "FlurryNativeCustomEvent.h"
-#import "FlurryAdNative.h"
 #import "FlurryNativeAdAdapter.h"
-#import "MPNativeAd.h"
-#import "MPNativeAdError.h"
-#import "MPLogging.h"
+#if __has_include("MoPub.h")
+    #import "MPNativeAd.h"
+    #import "MPNativeAdError.h"
+    #import "MPLogging.h"
+#endif
 #import "FlurryMPConfig.h"
 
 

--- a/Flurry/FlurryNativeVideoAdRenderer.h
+++ b/Flurry/FlurryNativeVideoAdRenderer.h
@@ -7,7 +7,15 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "MPNativeAdRenderer.h"
+
+#if __has_include(<MoPub/MoPub.h>)
+    #import <MoPub/MoPub.h>
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MoPub.h>
+#else
+    #import "MPNativeAdRenderer"
+#endif
+
 
 @class MPNativeAdRendererConfiguration;
 @class MPStaticNativeAdRendererSettings;

--- a/Flurry/FlurryNativeVideoAdRenderer.m
+++ b/Flurry/FlurryNativeVideoAdRenderer.m
@@ -23,7 +23,7 @@
 /**
  * Renderer that supports both static and video Flurry native ads
  */
-@interface FlurryNativeVideoAdRenderer () //<MPNativeAdRendererImageHandlerDelegate>
+@interface FlurryNativeVideoAdRenderer () <MPNativeAdRendererImageHandlerDelegate>
 
 @property (nonatomic) UIView<MPNativeAdRendering> *adView;
 @property (nonatomic) FlurryNativeAdAdapter<MPNativeAdAdapter> *adapter;
@@ -54,8 +54,8 @@
         MOPUBNativeVideoAdRendererSettings *settings = (MOPUBNativeVideoAdRendererSettings *)rendererSettings;
         _renderingViewClass = settings.renderingViewClass;
         _viewSizeHandler = [settings.viewSizeHandler copy];
-        _rendererImageHandler = nil; //[MPNativeAdRendererImageHandler new];
-        //_rendererImageHandler.delegate = self;
+        _rendererImageHandler = [MPNativeAdRendererImageHandler new];
+        _rendererImageHandler.delegate = self;
     }
     
     return self;
@@ -118,12 +118,12 @@
     
     if (superview) {
         if ([self.adapter.properties objectForKey:kAdIconImageKey] && [self.adView respondsToSelector:@selector(nativeIconImageView)]) {
-            //[self.rendererImageHandler loadImageForURL:[NSURL URLWithString:[self.adapter.properties objectForKey:kAdIconImageKey]] intoImageView:self.adView.nativeIconImageView];
+            [self.rendererImageHandler loadImageForURL:[NSURL URLWithString:[self.adapter.properties objectForKey:kAdIconImageKey]] intoImageView:self.adView.nativeIconImageView];
         }
         
         if (!([self.adapter respondsToSelector:@selector(mainMediaView)] && [self.adapter mainMediaView])) {
             if ([self.adapter.properties objectForKey:kAdMainImageKey] && [self.adView respondsToSelector:@selector(nativeMainImageView)]) {
-                //[self.rendererImageHandler loadImageForURL:[NSURL URLWithString:[self.adapter.properties objectForKey:kAdMainImageKey]] intoImageView:self.adView.nativeMainImageView];
+                [self.rendererImageHandler loadImageForURL:[NSURL URLWithString:[self.adapter.properties objectForKey:kAdMainImageKey]] intoImageView:self.adView.nativeMainImageView];
             }
         }
         

--- a/Flurry/FlurryNativeVideoAdRenderer.m
+++ b/Flurry/FlurryNativeVideoAdRenderer.m
@@ -8,20 +8,22 @@
 
 #import "FlurryNativeAdAdapter.h"
 #import "FlurryNativeVideoAdRenderer.h"
-#import "MOPUBNativeVideoAdRendererSettings.h"
-#import "MPNativeAdRendererConfiguration.h"
-#import "MPNativeAdRenderer.h"
-#import "MPNativeAdRendering.h"
-#import "MPNativeAdAdapter.h"
-#import "MPNativeAdConstants.h"
-#import "MPNativeAdError.h"
-#import "MPNativeAdRendererImageHandler.h"
-#import "MPNativeAdRenderingImageLoader.h"
+#if __has_include("MoPub.h")
+    #import "MOPUBNativeVideoAdRendererSettings.h"
+    #import "MPNativeAdRendererConfiguration.h"
+    #import "MPNativeAdRenderer.h"
+    #import "MPNativeAdRendering.h"
+    #import "MPNativeAdAdapter.h"
+    #import "MPNativeAdConstants.h"
+    #import "MPNativeAdError.h"
+    #import "MPNativeAdRendererImageHandler.h"
+    #import "MPNativeAdRenderingImageLoader.h"
+#endif
 
 /**
  * Renderer that supports both static and video Flurry native ads
  */
-@interface FlurryNativeVideoAdRenderer () <MPNativeAdRendererImageHandlerDelegate>
+@interface FlurryNativeVideoAdRenderer () //<MPNativeAdRendererImageHandlerDelegate>
 
 @property (nonatomic) UIView<MPNativeAdRendering> *adView;
 @property (nonatomic) FlurryNativeAdAdapter<MPNativeAdAdapter> *adapter;
@@ -52,8 +54,8 @@
         MOPUBNativeVideoAdRendererSettings *settings = (MOPUBNativeVideoAdRendererSettings *)rendererSettings;
         _renderingViewClass = settings.renderingViewClass;
         _viewSizeHandler = [settings.viewSizeHandler copy];
-        _rendererImageHandler = [MPNativeAdRendererImageHandler new];
-        _rendererImageHandler.delegate = self;
+        _rendererImageHandler = nil; //[MPNativeAdRendererImageHandler new];
+        //_rendererImageHandler.delegate = self;
     }
     
     return self;
@@ -116,12 +118,12 @@
     
     if (superview) {
         if ([self.adapter.properties objectForKey:kAdIconImageKey] && [self.adView respondsToSelector:@selector(nativeIconImageView)]) {
-            [self.rendererImageHandler loadImageForURL:[NSURL URLWithString:[self.adapter.properties objectForKey:kAdIconImageKey]] intoImageView:self.adView.nativeIconImageView];
+            //[self.rendererImageHandler loadImageForURL:[NSURL URLWithString:[self.adapter.properties objectForKey:kAdIconImageKey]] intoImageView:self.adView.nativeIconImageView];
         }
         
         if (!([self.adapter respondsToSelector:@selector(mainMediaView)] && [self.adapter mainMediaView])) {
             if ([self.adapter.properties objectForKey:kAdMainImageKey] && [self.adView respondsToSelector:@selector(nativeMainImageView)]) {
-                [self.rendererImageHandler loadImageForURL:[NSURL URLWithString:[self.adapter.properties objectForKey:kAdMainImageKey]] intoImageView:self.adView.nativeMainImageView];
+                //[self.rendererImageHandler loadImageForURL:[NSURL URLWithString:[self.adapter.properties objectForKey:kAdMainImageKey]] intoImageView:self.adView.nativeMainImageView];
             }
         }
         

--- a/IronSource/IronSourceInterstitialCustomEvent.h
+++ b/IronSource/IronSourceInterstitialCustomEvent.h
@@ -3,9 +3,11 @@
 //
 
 #if __has_include(<MoPub/MoPub.h>)
-    #import "MPInterstitialCustomEvent.h"
+    #import <MoPub/MoPub.h>
 #elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPInterstitialCustomEvent.h>
+    #import <MoPubSDKFramework/MoPub.h>
+#else
+    #import "MPInterstitialCustomEvent.h"
 #endif
 #import <IronSource/IronSource.h>
 

--- a/IronSource/IronSourceInterstitialCustomEvent.h
+++ b/IronSource/IronSourceInterstitialCustomEvent.h
@@ -1,8 +1,12 @@
 //
-//  MOPUBISAdapterIronSource.h
+//  IronSourceInterstitialCustomEvent.h
 //
 
-#import "MPInterstitialCustomEvent.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPInterstitialCustomEvent.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPInterstitialCustomEvent.h>
+#endif
 #import <IronSource/IronSource.h>
 
 @interface IronSourceInterstitialCustomEvent : MPInterstitialCustomEvent <ISDemandOnlyInterstitialDelegate>

--- a/IronSource/IronSourceInterstitialCustomEvent.m
+++ b/IronSource/IronSourceInterstitialCustomEvent.m
@@ -3,12 +3,9 @@
 //
 
 #import "IronSourceInterstitialCustomEvent.h"
-#if __has_include(<MoPub/MoPub.h>)
+#if __has_include("MoPub.h")
     #import "MPLogging.h"
     #import "MoPub.h"
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPLogging.h>
-    #import <MoPubSDKFramework/MoPub.h>
 #endif
 #import "IronSourceConstants.h"
 

--- a/IronSource/IronSourceInterstitialCustomEvent.m
+++ b/IronSource/IronSourceInterstitialCustomEvent.m
@@ -1,11 +1,16 @@
 //
-//  MOPUBISAdapterIronSource.m
+//  IronSourceInterstitialCustomEvent.m
 //
 
 #import "IronSourceInterstitialCustomEvent.h"
-#import "MPLogging.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPLogging.h"
+    #import "MoPub.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPLogging.h>
+    #import <MoPubSDKFramework/MoPub.h>
+#endif
 #import "IronSourceConstants.h"
-#import "MoPub.h"
 
 @interface IronSourceInterstitialCustomEvent()
 @property (nonatomic, strong) NSString *placementName;

--- a/IronSource/IronSourceRewardedVideoCustomEvent.h
+++ b/IronSource/IronSourceRewardedVideoCustomEvent.h
@@ -1,9 +1,14 @@
 //
-//  MOPUBRVAdapterIronSource.h
+//  IronSourceRewardedVideoCustomEvent.h
 //
 
-#import "MPRewardedVideoReward.h"
-#import "MPRewardedVideoCustomEvent.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPRewardedVideoReward.h"
+    #import "MPRewardedVideoCustomEvent.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPRewardedVideoReward.h>
+    #import <MoPubSDKFramework/MPRewardedVideoCustomEvent.h>
+#endif
 #import <IronSource/IronSource.h>
 
 @interface IronSourceRewardedVideoCustomEvent : MPRewardedVideoCustomEvent <ISDemandOnlyRewardedVideoDelegate>

--- a/IronSource/IronSourceRewardedVideoCustomEvent.h
+++ b/IronSource/IronSourceRewardedVideoCustomEvent.h
@@ -3,11 +3,12 @@
 //
 
 #if __has_include(<MoPub/MoPub.h>)
+    #import <MoPub/MoPub.h>
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MoPub.h>
+#else
     #import "MPRewardedVideoReward.h"
     #import "MPRewardedVideoCustomEvent.h"
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPRewardedVideoReward.h>
-    #import <MoPubSDKFramework/MPRewardedVideoCustomEvent.h>
 #endif
 #import <IronSource/IronSource.h>
 

--- a/IronSource/IronSourceRewardedVideoCustomEvent.m
+++ b/IronSource/IronSourceRewardedVideoCustomEvent.m
@@ -4,12 +4,9 @@
 
 #import "IronSourceRewardedVideoCustomEvent.h"
 #import "IronSourceConstants.h"
-#if __has_include(<MoPub/MoPub.h>)
+#if __has_include("MoPub.h")
     #import "MPLogging.h"
     #import "MoPub.h"
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPLogging.h>
-    #import <MoPubSDKFramework/MoPub.h>
 #endif
 
 @interface IronSourceRewardedVideoCustomEvent()

--- a/IronSource/IronSourceRewardedVideoCustomEvent.m
+++ b/IronSource/IronSourceRewardedVideoCustomEvent.m
@@ -1,11 +1,16 @@
 //
-//  MOPUBRVAdapterIronSource.m
+//  IronSourceRewardedVideoCustomEvent.m
 //
 
 #import "IronSourceRewardedVideoCustomEvent.h"
 #import "IronSourceConstants.h"
-#import "MPLogging.h"
-#import "MoPub.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPLogging.h"
+    #import "MoPub.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPLogging.h>
+    #import <MoPubSDKFramework/MoPub.h>
+#endif
 
 @interface IronSourceRewardedVideoCustomEvent()
 

--- a/OnebyAOL/MPMillennialBannerCustomEvent.m
+++ b/OnebyAOL/MPMillennialBannerCustomEvent.m
@@ -5,8 +5,14 @@
 //
 
 #import "MPMillennialBannerCustomEvent.h"
-#import "MPLogging.h"
-#import "MPAdConfiguration.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPLogging.h"
+    #import "MPAdConfiguration.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPLogging.h>
+// TODO: enable this import after MPAdConfiguration.h has been added to MoPubSDKFramework
+//    #import <MoPubSDKFramework/MPAdConfiguration.h>
+#endif
 #import "MMAdapterVersion.h"
 
 static NSString *const kMoPubMMAdapterAdUnit = @"adUnitID";

--- a/OnebyAOL/MPMillennialBannerCustomEvent.m
+++ b/OnebyAOL/MPMillennialBannerCustomEvent.m
@@ -5,13 +5,9 @@
 //
 
 #import "MPMillennialBannerCustomEvent.h"
-#if __has_include(<MoPub/MoPub.h>)
+#if __has_include("MoPub.h")
     #import "MPLogging.h"
     #import "MPAdConfiguration.h"
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPLogging.h>
-// TODO: enable this import after MPAdConfiguration.h has been added to MoPubSDKFramework
-//    #import <MoPubSDKFramework/MPAdConfiguration.h>
 #endif
 #import "MMAdapterVersion.h"
 

--- a/OnebyAOL/MPMillennialInterstitialCustomEvent.m
+++ b/OnebyAOL/MPMillennialInterstitialCustomEvent.m
@@ -5,7 +5,11 @@
 //
 
 #import "MPMillennialInterstitialCustomEvent.h"
-#import "MPLogging.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPLogging.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPLogging.h>
+#endif
 #import "MMAdapterVersion.h"
 
 static NSString *const kMoPubMMAdapterAdUnit = @"adUnitID";

--- a/OnebyAOL/MPMillennialInterstitialCustomEvent.m
+++ b/OnebyAOL/MPMillennialInterstitialCustomEvent.m
@@ -5,10 +5,8 @@
 //
 
 #import "MPMillennialInterstitialCustomEvent.h"
-#if __has_include(<MoPub/MoPub.h>)
+#if __has_include("MoPub.h")
     #import "MPLogging.h"
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPLogging.h>
 #endif
 #import "MMAdapterVersion.h"
 

--- a/OnebyAOL/MPMillennialRewardedVideoCustomEvent.m
+++ b/OnebyAOL/MPMillennialRewardedVideoCustomEvent.m
@@ -7,12 +7,9 @@
 
 #import "MPMillennialRewardedVideoCustomEvent.h"
 #import "MPMillennialInterstitialCustomEvent.h"
-#if __has_include(<MoPub/MoPub.h>)
+#if __has_include("MoPub.h")
     #import "MPLogging.h"
     #import "MPRewardedVideoCustomEvent+Caching.h"
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPLogging.h>
-    #import <MoPubSDKFramework/MPRewardedVideoCustomEvent+Caching.h>
 #endif
 #import <MMAdSDK/MMAd+Experimental.h>
 #import "MMAdapterVersion.h"

--- a/OnebyAOL/MPMillennialRewardedVideoCustomEvent.m
+++ b/OnebyAOL/MPMillennialRewardedVideoCustomEvent.m
@@ -7,11 +7,16 @@
 
 #import "MPMillennialRewardedVideoCustomEvent.h"
 #import "MPMillennialInterstitialCustomEvent.h"
-#import "MPLogging.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPLogging.h"
+    #import "MPRewardedVideoCustomEvent+Caching.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPLogging.h>
+    #import <MoPubSDKFramework/MPRewardedVideoCustomEvent+Caching.h>
+#endif
 #import <MMAdSDK/MMAd+Experimental.h>
 #import "MMAdapterVersion.h"
 #import <objc/runtime.h>
-#import "MPRewardedVideoCustomEvent+Caching.h"
 
 static NSString *const kMoPubMMAdapterAdUnit = @"adUnitID";
 static NSString *const kMoPubMMAdapterDCN = @"dcn";

--- a/OnebyAOL/MillennialNativeAdAdapter.m
+++ b/OnebyAOL/MillennialNativeAdAdapter.m
@@ -14,11 +14,10 @@ NSString * const kAdMainImageViewKey = @"mmmainimage";
 NSString * const kAdIconImageViewKey = @"mmiconimage";
 NSString * const kDisclaimerKey = @"mmdisclaimer";
 
-// TODO: reenable once MPAdImpressionTimer.h has been added to MoPubSDKFramework
 
-@interface MillennialNativeAdAdapter() //<MPAdImpressionTimerDelegate>
+@interface MillennialNativeAdAdapter() <MPAdImpressionTimerDelegate>
 
-//@property (nonatomic) MPAdImpressionTimer *impressionTimer;
+@property (nonatomic) MPAdImpressionTimer *impressionTimer;
 @property (nonatomic, strong) MMNativeAd *mmNativeAd;
 @property (nonatomic, strong) NSDictionary<NSString *, id> *mmAdProperties;
 
@@ -62,8 +61,8 @@ NSString * const kDisclaimerKey = @"mmdisclaimer";
         _mmAdProperties = properties;
 
         // Impression tracking
-        //_impressionTimer = [[MPAdImpressionTimer alloc] initWithRequiredSecondsForImpression:0.0 requiredViewVisibilityPercentage:0.5];
-        //_impressionTimer.delegate = self;
+        _impressionTimer = [[MPAdImpressionTimer alloc] initWithRequiredSecondsForImpression:0.0 requiredViewVisibilityPercentage:0.5];
+        _impressionTimer.delegate = self;
 
     }
     return self;
@@ -88,7 +87,7 @@ NSString * const kDisclaimerKey = @"mmdisclaimer";
 #pragma mark - Impression tracking
 
 - (void)willAttachToView:(UIView *)view {
-    //[self.impressionTimer startTrackingView:view];
+    [self.impressionTimer startTrackingView:view];
 }
 
 - (void)adViewWillLogImpression:(UIView *)adView {

--- a/OnebyAOL/MillennialNativeAdAdapter.m
+++ b/OnebyAOL/MillennialNativeAdAdapter.m
@@ -5,100 +5,98 @@
 //
 
 #import "MillennialNativeAdAdapter.h"
-#if __has_include(<MoPub/MoPub.h>)
+#if __has_include("MoPub.h")
     #import "MPNativeAdConstants.h"
     #import "MPAdImpressionTimer.h"
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPNativeAdConstants.h>
-// TODO: enable this import (and disabled code below) after MPAdImpressionTimer.h has been added to MoPubSDKFramework
-//    #import <MoPubSDKFramework/MPAdImpressionTimer.h>
 #endif
 
 NSString * const kAdMainImageViewKey = @"mmmainimage";
 NSString * const kAdIconImageViewKey = @"mmiconimage";
 NSString * const kDisclaimerKey = @"mmdisclaimer";
 
-//@interface MillennialNativeAdAdapter() <MPAdImpressionTimerDelegate>
-//
+// TODO: reenable once MPAdImpressionTimer.h has been added to MoPubSDKFramework
+
+@interface MillennialNativeAdAdapter() //<MPAdImpressionTimerDelegate>
+
 //@property (nonatomic) MPAdImpressionTimer *impressionTimer;
-//@property (nonatomic, strong) MMNativeAd *mmNativeAd;
-//@property (nonatomic, strong) NSDictionary<NSString *, id> *mmAdProperties;
-//
-//@end
-//
-//@implementation MillennialNativeAdAdapter
-//
-//- (instancetype)initWithMMNativeAd:(MMNativeAd *)ad {
-//    if (self = [super init]) {
-//        NSMutableDictionary<NSString *, id> *properties = [NSMutableDictionary dictionary];
-//
-//        if (ad.title.text) {
-//            properties[kAdTitleKey] = ad.title.text;
-//        }
-//
-//        if (ad.body.text) {
-//            properties[kAdTextKey] = ad.body.text;
-//        }
-//
-//        if (ad.callToActionButton.titleLabel.text) {
-//            properties[kAdCTATextKey] = ad.callToActionButton.titleLabel.text;
-//        }
-//
-//        if (ad.rating.text) {
-//            properties[kAdStarRatingKey] = @(ad.rating.text.integerValue);
-//        }
-//
-//        if (ad.mainImageView.image) {
-//            properties[kAdMainImageViewKey] = ad.mainImageView;
-//        }
-//
-//        if (ad.iconImageView.image) {
-//            properties[kAdIconImageViewKey] = ad.iconImageView;
-//        }
-//
-//        if (ad.disclaimer.text) {
-//            properties[kDisclaimerKey] = ad.disclaimer.text;
-//        }
-//
-//        _mmNativeAd = ad;
-//        _mmAdProperties = properties;
-//
-//        // Impression tracking
-//        _impressionTimer = [[MPAdImpressionTimer alloc] initWithRequiredSecondsForImpression:0.0 requiredViewVisibilityPercentage:0.5];
-//        _impressionTimer.delegate = self;
-//
-//    }
-//    return self;
-//}
-//
-//#pragma mark - MPNativeAdAdapter
-//
-//- (NSDictionary *)properties {
-//    return self.mmAdProperties;
-//}
-//
-//- (NSURL *)defaultActionURL {
-//    return nil;
-//}
-//
-//#pragma mark - Click Tracking
-//
-//- (void)displayContentForURL:(NSURL *)URL rootViewController:(UIViewController *)controller {
-//    [self.mmNativeAd invokeDefaultAction];
-//}
-//
-//#pragma mark - Impression tracking
-//
-//- (void)willAttachToView:(UIView *)view {
-//    [self.impressionTimer startTrackingView:view];
-//}
-//
-//- (void)adViewWillLogImpression:(UIView *)adView {
-//    [self.delegate nativeAdWillLogImpression:self];
-//
-//    // Handle the impression
-//    [self.mmNativeAd fireImpression];
-//}
-//
-//@end
+@property (nonatomic, strong) MMNativeAd *mmNativeAd;
+@property (nonatomic, strong) NSDictionary<NSString *, id> *mmAdProperties;
+
+@end
+
+@implementation MillennialNativeAdAdapter
+
+- (instancetype)initWithMMNativeAd:(MMNativeAd *)ad {
+    if (self = [super init]) {
+        NSMutableDictionary<NSString *, id> *properties = [NSMutableDictionary dictionary];
+
+        if (ad.title.text) {
+            properties[kAdTitleKey] = ad.title.text;
+        }
+
+        if (ad.body.text) {
+            properties[kAdTextKey] = ad.body.text;
+        }
+
+        if (ad.callToActionButton.titleLabel.text) {
+            properties[kAdCTATextKey] = ad.callToActionButton.titleLabel.text;
+        }
+
+        if (ad.rating.text) {
+            properties[kAdStarRatingKey] = @(ad.rating.text.integerValue);
+        }
+
+        if (ad.mainImageView.image) {
+            properties[kAdMainImageViewKey] = ad.mainImageView;
+        }
+
+        if (ad.iconImageView.image) {
+            properties[kAdIconImageViewKey] = ad.iconImageView;
+        }
+
+        if (ad.disclaimer.text) {
+            properties[kDisclaimerKey] = ad.disclaimer.text;
+        }
+
+        _mmNativeAd = ad;
+        _mmAdProperties = properties;
+
+        // Impression tracking
+        //_impressionTimer = [[MPAdImpressionTimer alloc] initWithRequiredSecondsForImpression:0.0 requiredViewVisibilityPercentage:0.5];
+        //_impressionTimer.delegate = self;
+
+    }
+    return self;
+}
+
+#pragma mark - MPNativeAdAdapter
+
+- (NSDictionary *)properties {
+    return self.mmAdProperties;
+}
+
+- (NSURL *)defaultActionURL {
+    return nil;
+}
+
+#pragma mark - Click Tracking
+
+- (void)displayContentForURL:(NSURL *)URL rootViewController:(UIViewController *)controller {
+    [self.mmNativeAd invokeDefaultAction];
+}
+
+#pragma mark - Impression tracking
+
+- (void)willAttachToView:(UIView *)view {
+    //[self.impressionTimer startTrackingView:view];
+}
+
+- (void)adViewWillLogImpression:(UIView *)adView {
+    [self.delegate nativeAdWillLogImpression:self];
+
+    // Handle the impression
+    [self.mmNativeAd fireImpression];
+}
+
+@end
 

--- a/OnebyAOL/MillennialNativeAdAdapter.m
+++ b/OnebyAOL/MillennialNativeAdAdapter.m
@@ -14,7 +14,6 @@ NSString * const kAdMainImageViewKey = @"mmmainimage";
 NSString * const kAdIconImageViewKey = @"mmiconimage";
 NSString * const kDisclaimerKey = @"mmdisclaimer";
 
-
 @interface MillennialNativeAdAdapter() <MPAdImpressionTimerDelegate>
 
 @property (nonatomic) MPAdImpressionTimer *impressionTimer;
@@ -98,4 +97,3 @@ NSString * const kDisclaimerKey = @"mmdisclaimer";
 }
 
 @end
-

--- a/OnebyAOL/MillennialNativeAdAdapter.m
+++ b/OnebyAOL/MillennialNativeAdAdapter.m
@@ -5,93 +5,100 @@
 //
 
 #import "MillennialNativeAdAdapter.h"
-#import "MPNativeAdConstants.h"
-#import "MPAdImpressionTimer.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPNativeAdConstants.h"
+    #import "MPAdImpressionTimer.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPNativeAdConstants.h>
+// TODO: enable this import (and disabled code below) after MPAdImpressionTimer.h has been added to MoPubSDKFramework
+//    #import <MoPubSDKFramework/MPAdImpressionTimer.h>
+#endif
 
 NSString * const kAdMainImageViewKey = @"mmmainimage";
 NSString * const kAdIconImageViewKey = @"mmiconimage";
 NSString * const kDisclaimerKey = @"mmdisclaimer";
 
-@interface MillennialNativeAdAdapter() <MPAdImpressionTimerDelegate>
+//@interface MillennialNativeAdAdapter() <MPAdImpressionTimerDelegate>
+//
+//@property (nonatomic) MPAdImpressionTimer *impressionTimer;
+//@property (nonatomic, strong) MMNativeAd *mmNativeAd;
+//@property (nonatomic, strong) NSDictionary<NSString *, id> *mmAdProperties;
+//
+//@end
+//
+//@implementation MillennialNativeAdAdapter
+//
+//- (instancetype)initWithMMNativeAd:(MMNativeAd *)ad {
+//    if (self = [super init]) {
+//        NSMutableDictionary<NSString *, id> *properties = [NSMutableDictionary dictionary];
+//
+//        if (ad.title.text) {
+//            properties[kAdTitleKey] = ad.title.text;
+//        }
+//
+//        if (ad.body.text) {
+//            properties[kAdTextKey] = ad.body.text;
+//        }
+//
+//        if (ad.callToActionButton.titleLabel.text) {
+//            properties[kAdCTATextKey] = ad.callToActionButton.titleLabel.text;
+//        }
+//
+//        if (ad.rating.text) {
+//            properties[kAdStarRatingKey] = @(ad.rating.text.integerValue);
+//        }
+//
+//        if (ad.mainImageView.image) {
+//            properties[kAdMainImageViewKey] = ad.mainImageView;
+//        }
+//
+//        if (ad.iconImageView.image) {
+//            properties[kAdIconImageViewKey] = ad.iconImageView;
+//        }
+//
+//        if (ad.disclaimer.text) {
+//            properties[kDisclaimerKey] = ad.disclaimer.text;
+//        }
+//
+//        _mmNativeAd = ad;
+//        _mmAdProperties = properties;
+//
+//        // Impression tracking
+//        _impressionTimer = [[MPAdImpressionTimer alloc] initWithRequiredSecondsForImpression:0.0 requiredViewVisibilityPercentage:0.5];
+//        _impressionTimer.delegate = self;
+//
+//    }
+//    return self;
+//}
+//
+//#pragma mark - MPNativeAdAdapter
+//
+//- (NSDictionary *)properties {
+//    return self.mmAdProperties;
+//}
+//
+//- (NSURL *)defaultActionURL {
+//    return nil;
+//}
+//
+//#pragma mark - Click Tracking
+//
+//- (void)displayContentForURL:(NSURL *)URL rootViewController:(UIViewController *)controller {
+//    [self.mmNativeAd invokeDefaultAction];
+//}
+//
+//#pragma mark - Impression tracking
+//
+//- (void)willAttachToView:(UIView *)view {
+//    [self.impressionTimer startTrackingView:view];
+//}
+//
+//- (void)adViewWillLogImpression:(UIView *)adView {
+//    [self.delegate nativeAdWillLogImpression:self];
+//
+//    // Handle the impression
+//    [self.mmNativeAd fireImpression];
+//}
+//
+//@end
 
-@property (nonatomic) MPAdImpressionTimer *impressionTimer;
-@property (nonatomic, strong) MMNativeAd *mmNativeAd;
-@property (nonatomic, strong) NSDictionary<NSString *, id> *mmAdProperties;
-
-@end
-
-@implementation MillennialNativeAdAdapter
-
-- (instancetype)initWithMMNativeAd:(MMNativeAd *)ad {
-    if (self = [super init]) {
-        NSMutableDictionary<NSString *, id> *properties = [NSMutableDictionary dictionary];
-
-        if (ad.title.text) {
-            properties[kAdTitleKey] = ad.title.text;
-        }
-
-        if (ad.body.text) {
-            properties[kAdTextKey] = ad.body.text;
-        }
-
-        if (ad.callToActionButton.titleLabel.text) {
-            properties[kAdCTATextKey] = ad.callToActionButton.titleLabel.text;
-        }
-
-        if (ad.rating.text) {
-            properties[kAdStarRatingKey] = @(ad.rating.text.integerValue);
-        }
-
-        if (ad.mainImageView.image) {
-            properties[kAdMainImageViewKey] = ad.mainImageView;
-        }
-
-        if (ad.iconImageView.image) {
-            properties[kAdIconImageViewKey] = ad.iconImageView;
-        }
-
-        if (ad.disclaimer.text) {
-            properties[kDisclaimerKey] = ad.disclaimer.text;
-        }
-
-        _mmNativeAd = ad;
-        _mmAdProperties = properties;
-
-        // Impression tracking
-        _impressionTimer = [[MPAdImpressionTimer alloc] initWithRequiredSecondsForImpression:0.0 requiredViewVisibilityPercentage:0.5];
-        _impressionTimer.delegate = self;
-
-    }
-    return self;
-}
-
-#pragma mark - MPNativeAdAdapter
-
-- (NSDictionary *)properties {
-    return self.mmAdProperties;
-}
-
-- (NSURL *)defaultActionURL {
-    return nil;
-}
-
-#pragma mark - Click Tracking
-
-- (void)displayContentForURL:(NSURL *)URL rootViewController:(UIViewController *)controller {
-    [self.mmNativeAd invokeDefaultAction];
-}
-
-#pragma mark - Impression tracking
-
-- (void)willAttachToView:(UIView *)view {
-    [self.impressionTimer startTrackingView:view];
-}
-
-- (void)adViewWillLogImpression:(UIView *)adView {
-    [self.delegate nativeAdWillLogImpression:self];
-
-    // Handle the impression
-    [self.mmNativeAd fireImpression];
-}
-
-@end

--- a/OnebyAOL/MillennialNativeCustomEvent.m
+++ b/OnebyAOL/MillennialNativeCustomEvent.m
@@ -6,12 +6,9 @@
 
 #import "MillennialNativeCustomEvent.h"
 #import "MillennialNativeAdAdapter.h"
-#if __has_include(<MoPub/MoPub.h>)
+#if __has_include("MoPub.h")
     #import "MPLogging.h"
     #import "MPNativeAdError.h"
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPLogging.h>
-    #import <MoPubSDKFramework/MPNativeAdError.h>
 #endif
 #import "MMAdapterVersion.h"
 

--- a/OnebyAOL/MillennialNativeCustomEvent.m
+++ b/OnebyAOL/MillennialNativeCustomEvent.m
@@ -6,8 +6,13 @@
 
 #import "MillennialNativeCustomEvent.h"
 #import "MillennialNativeAdAdapter.h"
-#import "MPNativeAdError.h"
-#import "MPLogging.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPLogging.h"
+    #import "MPNativeAdError.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPLogging.h>
+    #import <MoPubSDKFramework/MPNativeAdError.h>
+#endif
 #import "MMAdapterVersion.h"
 
 #import <MMAdSDK/MMAdSDK.h>

--- a/Tapjoy/TapjoyInterstitialCustomEvent.m
+++ b/Tapjoy/TapjoyInterstitialCustomEvent.m
@@ -2,12 +2,9 @@
 #import "TapjoyInterstitialCustomEvent.h"
 #import <Tapjoy/TJPlacement.h>
 #import <Tapjoy/Tapjoy.h>
-#if __has_include(<MoPub/MoPub.h>)
+#if __has_include("MoPub.h")
     #import "MPLogging.h"
     #import "MoPub.h"
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPLogging.h>
-    #import <MoPubSDKFramework/MoPub.h>
 #endif
 
 @interface TapjoyInterstitialCustomEvent () <TJPlacementDelegate>

--- a/Tapjoy/TapjoyInterstitialCustomEvent.m
+++ b/Tapjoy/TapjoyInterstitialCustomEvent.m
@@ -2,8 +2,13 @@
 #import "TapjoyInterstitialCustomEvent.h"
 #import <Tapjoy/TJPlacement.h>
 #import <Tapjoy/Tapjoy.h>
-#import "MPLogging.h"
-#import "MoPub.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPLogging.h"
+    #import "MoPub.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPLogging.h>
+    #import <MoPubSDKFramework/MoPub.h>
+#endif
 
 @interface TapjoyInterstitialCustomEvent () <TJPlacementDelegate>
 @property (nonatomic, strong) TJPlacement *placement;

--- a/Tapjoy/TapjoyRewardedVideoCustomEvent.m
+++ b/Tapjoy/TapjoyRewardedVideoCustomEvent.m
@@ -2,12 +2,20 @@
 #import "TapjoyRewardedVideoCustomEvent.h"
 #import <Tapjoy/Tapjoy.h>
 #import <Tapjoy/TJPlacement.h>
-#import "MPRewardedVideoError.h"
-#import "MPLogging.h"
-#import "MPRewardedVideoReward.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPRewardedVideoError.h"
+    #import "MPLogging.h"
+    #import "MPRewardedVideoReward.h"
+    #import "MoPub.h"
+    #import "MPRewardedVideoCustomEvent+Caching.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPRewardedVideoError.h>
+    #import <MoPubSDKFramework/MPLogging.h>
+    #import <MoPubSDKFramework/MPRewardedVideoReward.h>
+    #import <MoPubSDKFramework/MoPub.h>
+    #import <MoPubSDKFramework/MPRewardedVideoCustomEvent+Caching.h>
+#endif
 #import "TapjoyGlobalMediationSettings.h"
-#import "MoPub.h"
-#import "MPRewardedVideoCustomEvent+Caching.h"
 
 @interface TapjoyRewardedVideoCustomEvent () <TJPlacementDelegate, TJCVideoAdDelegate>
 @property (nonatomic, strong) TJPlacement *placement;

--- a/Tapjoy/TapjoyRewardedVideoCustomEvent.m
+++ b/Tapjoy/TapjoyRewardedVideoCustomEvent.m
@@ -2,18 +2,12 @@
 #import "TapjoyRewardedVideoCustomEvent.h"
 #import <Tapjoy/Tapjoy.h>
 #import <Tapjoy/TJPlacement.h>
-#if __has_include(<MoPub/MoPub.h>)
+#if __has_include("MoPub.h")
     #import "MPRewardedVideoError.h"
     #import "MPLogging.h"
     #import "MPRewardedVideoReward.h"
     #import "MoPub.h"
     #import "MPRewardedVideoCustomEvent+Caching.h"
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPRewardedVideoError.h>
-    #import <MoPubSDKFramework/MPLogging.h>
-    #import <MoPubSDKFramework/MPRewardedVideoReward.h>
-    #import <MoPubSDKFramework/MoPub.h>
-    #import <MoPubSDKFramework/MPRewardedVideoCustomEvent+Caching.h>
 #endif
 #import "TapjoyGlobalMediationSettings.h"
 

--- a/UnityAds/MPUnityRouter.m
+++ b/UnityAds/MPUnityRouter.m
@@ -5,11 +5,18 @@
 //  Copyright (c) 2016 MoPub. All rights reserved.
 //
 
-#import "MoPub.h"
 #import "MPUnityRouter.h"
 #import "UnityAdsInstanceMediationSettings.h"
-#import "MPRewardedVideoError.h"
-#import "MPRewardedVideo.h"
+
+#if __has_include(<MoPub/MoPub.h>)
+    #import <MoPub/MoPub.h>
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MoPub.h>
+#else
+    #import "MoPub.h"
+    #import "MPRewardedVideoError.h"
+    #import "MPRewardedVideo.h"
+#endif
 
 @interface MPUnityRouter ()
 

--- a/UnityAds/UnityAdsInstanceMediationSettings.h
+++ b/UnityAds/UnityAdsInstanceMediationSettings.h
@@ -9,6 +9,8 @@
 
 #if __has_include(<MoPub/MoPub.h>)
     #import <MoPub/MoPub.h>
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MoPub.h>
 #else
     #import "MPMediationSettingsProtocol.h"
 #endif

--- a/UnityAds/UnityAdsInterstitialCustomEvent.h
+++ b/UnityAds/UnityAdsInterstitialCustomEvent.h
@@ -8,7 +8,7 @@
 #if __has_include(<MoPub/MoPub.h>)
     #import <MoPub/MoPub.h>
 #elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPInterstitialCustomEvent.h>
+    #import <MoPubSDKFramework/MoPub.h>
 #else
     #import "MPInterstitialCustomEvent.h"
 #endif

--- a/UnityAds/UnityAdsInterstitialCustomEvent.h
+++ b/UnityAds/UnityAdsInterstitialCustomEvent.h
@@ -7,6 +7,8 @@
 
 #if __has_include(<MoPub/MoPub.h>)
     #import <MoPub/MoPub.h>
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPInterstitialCustomEvent.h>
 #else
     #import "MPInterstitialCustomEvent.h"
 #endif

--- a/UnityAds/UnityAdsInterstitialCustomEvent.m
+++ b/UnityAds/UnityAdsInterstitialCustomEvent.m
@@ -6,7 +6,7 @@
 //
 
 #import "UnityAdsInterstitialCustomEvent.h"
-#if __has_import("MoPub.h")
+#if __has_include("MoPub.h")
     #import "MPLogging.h"
 #endif
 #import "UnityAdsInstanceMediationSettings.h"

--- a/UnityAds/UnityAdsInterstitialCustomEvent.m
+++ b/UnityAds/UnityAdsInterstitialCustomEvent.m
@@ -6,9 +6,11 @@
 //
 
 #import "UnityAdsInterstitialCustomEvent.h"
-#import "MPUnityRouter.h"
-#import "MPLogging.h"
+#if __has_import("MoPub.h")
+    #import "MPLogging.h"
+#endif
 #import "UnityAdsInstanceMediationSettings.h"
+#import "MPUnityRouter.h"
 
 static NSString *const kMPUnityRewardedVideoGameId = @"gameId";
 static NSString *const kUnityAdsOptionPlacementIdKey = @"placementId";

--- a/UnityAds/UnityAdsRewardedVideoCustomEvent.h
+++ b/UnityAds/UnityAdsRewardedVideoCustomEvent.h
@@ -7,6 +7,8 @@
 
 #if __has_include(<MoPub/MoPub.h>)
     #import <MoPub/MoPub.h>
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MoPub.h>
 #else
     #import "MPRewardedVideoCustomEvent.h"
 #endif

--- a/UnityAds/UnityAdsRewardedVideoCustomEvent.m
+++ b/UnityAds/UnityAdsRewardedVideoCustomEvent.m
@@ -6,12 +6,14 @@
 //
 
 #import "UnityAdsRewardedVideoCustomEvent.h"
-#import "MPUnityRouter.h"
-#import "MPRewardedVideoReward.h"
-#import "MPRewardedVideoError.h"
-#import "MPLogging.h"
-#import "MPRewardedVideoCustomEvent+Caching.h"
 #import "UnityAdsInstanceMediationSettings.h"
+#import "MPUnityRouter.h"
+#if __has_include("MoPub.h")
+    #import "MPRewardedVideoReward.h"
+    #import "MPRewardedVideoError.h"
+    #import "MPLogging.h"
+    #import "MPRewardedVideoCustomEvent+Caching.h"
+#endif
 
 static NSString *const kMPUnityRewardedVideoGameId = @"gameId";
 static NSString *const kUnityAdsOptionPlacementIdKey = @"placementId";

--- a/Vungle/MPVungleRouter.m
+++ b/Vungle/MPVungleRouter.m
@@ -6,11 +6,18 @@
 //
 
 #import "MPVungleRouter.h"
-#import "MPLogging.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPLogging.h"
+    #import "MPRewardedVideoError.h"
+    #import "MPRewardedVideo.h"
+    #import "MoPub.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPLogging.h>
+    #import <MoPubSDKFramework/MPRewardedVideoError.h>
+    #import <MoPubSDKFramework/MPRewardedVideo.h>
+    #import <MoPubSDKFramework/MoPub.h>
+#endif
 #import "VungleInstanceMediationSettings.h"
-#import "MPRewardedVideoError.h"
-#import "MPRewardedVideo.h"
-#import "MoPub.h"
 
 static NSString *const VunglePluginVersion = @"6.2.0";
 

--- a/Vungle/MPVungleRouter.m
+++ b/Vungle/MPVungleRouter.m
@@ -6,16 +6,11 @@
 //
 
 #import "MPVungleRouter.h"
-#if __has_include(<MoPub/MoPub.h>)
+#if __has_include("MoPub.h")
     #import "MPLogging.h"
     #import "MPRewardedVideoError.h"
     #import "MPRewardedVideo.h"
     #import "MoPub.h"
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPLogging.h>
-    #import <MoPubSDKFramework/MPRewardedVideoError.h>
-    #import <MoPubSDKFramework/MPRewardedVideo.h>
-    #import <MoPubSDKFramework/MoPub.h>
 #endif
 #import "VungleInstanceMediationSettings.h"
 

--- a/Vungle/VungleInterstitialCustomEvent.m
+++ b/Vungle/VungleInterstitialCustomEvent.m
@@ -7,10 +7,8 @@
 
 #import <VungleSDK/VungleSDK.h>
 #import "VungleInterstitialCustomEvent.h"
-#if __has_include(<MoPub/MoPub.h>)
+#if __has_include("MoPub.h")
     #import "MPLogging.h"
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPLogging.h>
 #endif
 #import "MPVungleRouter.h"
 

--- a/Vungle/VungleInterstitialCustomEvent.m
+++ b/Vungle/VungleInterstitialCustomEvent.m
@@ -7,7 +7,11 @@
 
 #import <VungleSDK/VungleSDK.h>
 #import "VungleInterstitialCustomEvent.h"
-#import "MPLogging.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPLogging.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPLogging.h>
+#endif
 #import "MPVungleRouter.h"
 
 // If you need to play ads with vungle options, you may modify playVungleAdFromRootViewController and create an options dictionary and call the playAd:withOptions: method on the vungle SDK.

--- a/Vungle/VungleRewardedVideoCustomEvent.m
+++ b/Vungle/VungleRewardedVideoCustomEvent.m
@@ -6,13 +6,20 @@
 //
 
 #import "VungleRewardedVideoCustomEvent.h"
-#import "MPLogging.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import "MPLogging.h"
+    #import "MPRewardedVideoReward.h"
+    #import "MPRewardedVideoError.h"
+    #import "MPRewardedVideoCustomEvent+Caching.h"
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MPLogging.h>
+    #import <MoPubSDKFramework/MPRewardedVideoReward.h>
+    #import <MoPubSDKFramework/MPRewardedVideoError.h>
+    #import <MoPubSDKFramework/MPRewardedVideoCustomEvent+Caching.h>
+#endif
 #import <VungleSDK/VungleSDK.h>
-#import "MPRewardedVideoReward.h"
 #import "MPVungleRouter.h"
-#import "MPRewardedVideoError.h"
 #import "VungleInstanceMediationSettings.h"
-#import "MPRewardedVideoCustomEvent+Caching.h"
 
 @interface VungleRewardedVideoCustomEvent ()  <MPVungleRouterDelegate>
 

--- a/Vungle/VungleRewardedVideoCustomEvent.m
+++ b/Vungle/VungleRewardedVideoCustomEvent.m
@@ -6,16 +6,11 @@
 //
 
 #import "VungleRewardedVideoCustomEvent.h"
-#if __has_include(<MoPub/MoPub.h>)
+#if __has_include("MoPub.h")
     #import "MPLogging.h"
     #import "MPRewardedVideoReward.h"
     #import "MPRewardedVideoError.h"
     #import "MPRewardedVideoCustomEvent+Caching.h"
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MPLogging.h>
-    #import <MoPubSDKFramework/MPRewardedVideoReward.h>
-    #import <MoPubSDKFramework/MPRewardedVideoError.h>
-    #import <MoPubSDKFramework/MPRewardedVideoCustomEvent+Caching.h>
 #endif
 #import <VungleSDK/VungleSDK.h>
 #import "MPVungleRouter.h"


### PR DESCRIPTION
This is a first attempt at making iOS mediation work with the SDK framework. Doing this uncovered several files that are missing from the `MoPubSDKFramework.framework`:
* `MPError.h`
* `MPNativeAdUtils.h`
* `MPAdConfiguration.h`
* `MPAdImpressionTimer.h`
* `MPRealTimeTimer.h`
* `MPAdDestinationDisplayAgent.h`
* `MPNativeAdRendererImageHandler.h`
* `MPNativeCache.h`
* `MPNativeView.h`
* `MPCoreInstanceProvider.h`

Because of these missing files, I had to leave those imports commented out and sometimes disable relevant code (hence the WIPiness of this branch).

@caleb-lee @kdun let's synch up in the morning to figure out how to move forward from here, as mediation (and thus, the GDPR-enabled 5.0 release) for Unity is broken until this is resolved 😢 

I also couldn't update the adapters for the following networks since I lacked the frameworks to unblock them:
* Flurry
* AdColony
* UnityAds

I'll try to get frameworks for these in the morning to update the corresponding adapters as well (and uncover any additional missing files from the MoPub framework).