### PR TITLE
Roll back GDPR/consent passing for One by AOL

### DIFF
--- a/OnebyAOL/CHANGELOG.md
+++ b/OnebyAOL/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Changelog
+* 6.8.1.4
+    * Roll back GDPR consent passing per AOL's request.
+    * Fix a duplicate symbol issue in the native ad adapter.
+    
 * 6.8.1.3
     * update adapters to remove dependency on MPInstanceProvider
     * Update adapters to be compatible with MoPub iOS SDK framework

--- a/OnebyAOL/CHANGELOG.md
+++ b/OnebyAOL/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 * 6.8.1.4
-    * Roll back GDPR consent passing per AOL's request.
+    * MoPub will not be obtaining consent on behalf of One by AOL. Publishers should work directly with One by AOL to understand their obligations to comply with GDPR. Changes are updated on the supported partners page and our GDPR FAQ.
     * Fix a duplicate symbol issue in the native ad adapter.
     
 * 6.8.1.3

--- a/OnebyAOL/MPMillennialBannerCustomEvent.m
+++ b/OnebyAOL/MPMillennialBannerCustomEvent.m
@@ -36,17 +36,6 @@ static NSString *const kMoPubMMAdapterDCN = @"dcn";
                 [mmSDK initializeWithSettings:appSettings withUserSettings:nil];
                 MPLogDebug(@"Millennial adapter version: %@", self.version);
             }
-            
-            // Collect and pass the user's consent from MoPub onto the One by AOL SDK
-            if ( [MoPub sharedInstance].isGDPRApplicable == MPBoolYes )
-                [mmSDK setConsentRequired: TRUE];
-            else
-                [mmSDK setConsentRequired: FALSE];
-            
-            if ( [[MoPub sharedInstance] currentConsentStatus] == MPConsentStatusConsented ) {
-                [mmSDK setConsentDataValue: @"1" forKey:@"mopub"];
-            }
-            
         } else {
             self = nil; // No support below minimum OS.
         }

--- a/OnebyAOL/MPMillennialInterstitialCustomEvent.m
+++ b/OnebyAOL/MPMillennialInterstitialCustomEvent.m
@@ -35,17 +35,6 @@ static NSString *const kMoPubMMAdapterDCN = @"dcn";
                 [mmSDK initializeWithSettings:appSettings withUserSettings:nil];
                 MPLogDebug(@"Millennial adapter version: %@", self.version);
             }
-            
-            // Collect and pass the user's consent from MoPub onto the One by AOL SDK
-            if ( [MoPub sharedInstance].isGDPRApplicable == MPBoolYes )
-                [mmSDK setConsentRequired: TRUE];
-            else
-                [mmSDK setConsentRequired: FALSE];
-            
-            if ( [[MoPub sharedInstance] currentConsentStatus] == MPConsentStatusConsented ) {
-                [mmSDK setConsentDataValue: @"1" forKey:@"mopub"];
-            }
-            
         } else {
             self = nil; // No support below minimum OS.
         }

--- a/OnebyAOL/MPMillennialRewardedVideoCustomEvent.m
+++ b/OnebyAOL/MPMillennialRewardedVideoCustomEvent.m
@@ -67,17 +67,6 @@ static const char *const kMoPubMMRewardEventKey = "_rewardEvent_";
                              withUserSettings:nil];
                 MPLogDebug(@"Millennial adapter version: %@", self.version);
             }
-            
-            // Collect and pass the user's consent from MoPub onto the One by AOL SDK
-            if ( [MoPub sharedInstance].isGDPRApplicable == MPBoolYes )
-                [mmSDK setConsentRequired: TRUE];
-            else
-                [mmSDK setConsentRequired: FALSE];
-            
-            if ( [[MoPub sharedInstance] currentConsentStatus] == MPConsentStatusConsented ) {
-                [mmSDK setConsentDataValue: @"1" forKey:@"mopub"];
-            }
-            
         } else {
             self = nil; // No support below minimum OS.
         }

--- a/OnebyAOL/MillennialNativeAdAdapter.h
+++ b/OnebyAOL/MillennialNativeAdAdapter.h
@@ -16,9 +16,9 @@
 #import <Foundation/Foundation.h>
 
 // <MPNativeAdRendering> custom asset properties.
-extern NSString * const kAdMainImageViewKey;    // UIImageView *
-extern NSString * const kAdIconImageViewKey;    // UIImageView *
-extern NSString * const kDisclaimerKey;         // NSString *
+extern NSString * const kAdMainImageViewKey;      // UIImageView *
+extern NSString * const kMMAdIconImageViewKey;    // UIImageView *
+extern NSString * const kDisclaimerKey;           // NSString *
 
 @interface MillennialNativeAdAdapter : NSObject <MPNativeAdAdapter>
 

--- a/OnebyAOL/MillennialNativeAdAdapter.m
+++ b/OnebyAOL/MillennialNativeAdAdapter.m
@@ -11,7 +11,7 @@
 #endif
 
 NSString * const kAdMainImageViewKey = @"mmmainimage";
-NSString * const kAdIconImageViewKey = @"mmiconimage";
+NSString * const kMMAdIconImageViewKey = @"mmiconimage";
 NSString * const kDisclaimerKey = @"mmdisclaimer";
 
 @interface MillennialNativeAdAdapter() <MPAdImpressionTimerDelegate>
@@ -49,7 +49,7 @@ NSString * const kDisclaimerKey = @"mmdisclaimer";
         }
 
         if (ad.iconImageView.image) {
-            properties[kAdIconImageViewKey] = ad.iconImageView;
+            properties[kMMAdIconImageViewKey] = ad.iconImageView;
         }
 
         if (ad.disclaimer.text) {

--- a/OnebyAOL/MillennialNativeCustomEvent.m
+++ b/OnebyAOL/MillennialNativeCustomEvent.m
@@ -34,17 +34,6 @@ static NSString *const kMoPubMMAdapterDCN = @"dcn";
                 [mmSDK initializeWithSettings:appSettings withUserSettings:nil];
                 MPLogDebug(@"Millennial adapter version: %@", self.version);
             }
-            
-            // Collect and pass the user's consent from MoPub onto the One by AOL SDK
-            if ( [MoPub sharedInstance].isGDPRApplicable == MPBoolYes )
-                [mmSDK setConsentRequired: TRUE];
-            else
-                [mmSDK setConsentRequired: FALSE];
-            
-            if ( [[MoPub sharedInstance] currentConsentStatus] == MPConsentStatusConsented ) {
-                [mmSDK setConsentDataValue: @"1" forKey:@"mopub"];
-            }
-            
         } else {
             self = nil; // No support below minimum OS.
         }

--- a/OnebyAOL/MoPub-OnebyAOL-Podspecs/MoPub-OnebyAOL-Adapters.podspec
+++ b/OnebyAOL/MoPub-OnebyAOL-Podspecs/MoPub-OnebyAOL-Adapters.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
 s.name             = 'MoPub-OnebyAOL-Adapters'
-s.version          = '6.8.1.3'
+s.version          = '6.8.1.4'
 s.summary          = 'Aol Adapters for mediating through MoPub.'
 s.description      = <<-DESC
 Supported ad formats: Banner, Interstitial, Rewarded Video, Native.\n


### PR DESCRIPTION
* Roll back consent passing per AOL's request.
* Fix a duplicate symbol issue in the native ad adapter.