### PR TITLE
AdMob - Add interstitial manual impression tracking

### DIFF
--- a/AdMob/CHANGELOG.md
+++ b/AdMob/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Changelog
+  * 7.31.0.1
+    * Align MoPub's interstitial impression tracking to that of AdMob.
+        * Automatic impression tracking is disabled, and AdMob's `interstitialWillPresentScreen` is used to fire MoPub impressions.
+
   * 7.31.0.0
     * This version of the adapters has been certified with AdMob 7.31.0.
 

--- a/AdMob/MPGoogleAdMobInterstitialCustomEvent.m
+++ b/AdMob/MPGoogleAdMobInterstitialCustomEvent.m
@@ -71,6 +71,11 @@
     self.interstitial.delegate = nil;
 }
 
+- (BOOL)enableAutomaticImpressionAndClickTracking
+{
+    return NO;
+}
+
 #pragma mark - GADInterstitialDelegate
 
 - (void)interstitialDidReceiveAd:(GADInterstitial *)interstitial
@@ -90,6 +95,7 @@
     MPLogInfo(@"Google AdMob Interstitial will present");
     [self.delegate interstitialCustomEventWillAppear:self];
     [self.delegate interstitialCustomEventDidAppear:self];
+    [self.delegate trackImpression];
 }
 
 - (void)interstitialWillDismissScreen:(GADInterstitial *)ad

--- a/AdMob/MoPub-AdMob-PodSpecs/MoPub-AdMob-Adapters.podspec
+++ b/AdMob/MoPub-AdMob-PodSpecs/MoPub-AdMob-Adapters.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
 s.name             = 'MoPub-AdMob-Adapters'
-s.version          = '7.31.0.0'
+s.version          = '7.31.0.1'
 s.summary          = 'Google Adapters for mediating through MoPub.'
 s.description      = <<-DESC
 Supported ad formats: Banner, Interstitial, Rewarded Video, Native.\n


### PR DESCRIPTION
**Banner**: Not added because AdMob does not have an equivalent callback (https://developers.google.com/mobile-ads-sdk/docs/dfp/ios/banner#implementing_banner_events).

**Interstitial**: Added to when AdMob fires its `interstitialWillPresentScreen` delegate (https://developers.google.com/mobile-ads-sdk/docs/dfp/ios/interstitial#implementing_interstitial_events). This is a little early - right before the interstitial appears, but AdMob does not have a "didPresentScreen" delegate.
