### PR TITLE
Remove usage of deprecated property in MPGoogleAdMobInterstitialCustomEvent

### DIFF
--- a/AdMob/MPGoogleAdMobInterstitialCustomEvent.m
+++ b/AdMob/MPGoogleAdMobInterstitialCustomEvent.m
@@ -28,9 +28,8 @@
 - (void)requestInterstitialWithCustomEventInfo:(NSDictionary *)info
 {
     MPLogInfo(@"Requesting Google AdMob interstitial");
-    self.interstitial = [[GADInterstitial alloc] init];
-
-    self.interstitial.adUnitID = [info objectForKey:@"adUnitID"];
+    NSString *adUnitId = [info objectForKey:@"adUnitID"];
+    self.interstitial = [[GADInterstitial alloc] initWithAdUnitID:adUnitId];
     self.interstitial.delegate = self;
 
     GADRequest *request = [GADRequest request];


### PR DESCRIPTION
Use `initWithAdUnitID` for `GADInterstitial` instead of setting adUnitID directly.
Since `adUnitID` property has been marked as `readonly` since v7.4.0 of Google Admob mobile SDK.
Reference: https://developers.google.com/admob/ios/rel-notes