### PR TITLE
Using GADUnifiedNativeAd in place of deprecated classes

### DIFF
--- a/AdMob/MPGoogleAdMobNativeAdAdapter.h
+++ b/AdMob/MPGoogleAdMobNativeAdAdapter.h
@@ -8,26 +8,20 @@
 
 #import <GoogleMobileAds/GoogleMobileAds.h>
 
-/// This class implements the `MPNativeAdAdapter` and `GADNativeAdDelegate` protocols, that allow
+/// This class implements the `MPNativeAdAdapter` and `GADUnifiedNativeAdDelegate` protocols, that allow
 /// the MoPub SDK to interact with native ad objects obtained from Google Mobile Ads SDK.
-@interface MPGoogleAdMobNativeAdAdapter : NSObject<MPNativeAdAdapter, GADNativeAdDelegate>
+@interface MPGoogleAdMobNativeAdAdapter : NSObject<MPNativeAdAdapter, GADUnifiedNativeAdDelegate>
 
 /// MoPub native ad adapter delegate instance.
 @property(nonatomic, weak) id<MPNativeAdAdapterDelegate> delegate;
 
-/// Google Mobile Ads native app install ad instance.
-@property(nonatomic, strong) GADNativeAppInstallAd *adMobNativeAppInstallAd;
-
-/// Google Mobile Ads native content ad instance.
-@property(nonatomic, strong) GADNativeContentAd *adMobNativeContentAd;
+/// Google Mobile Ads unified native ad instance.
+@property(nonatomic, strong) GADUnifiedNativeAd *adMobUnifiedNativeAd;
 
 /// Google Mobile Ads container view to hold the AdChoices icon.
 @property(nonatomic, strong) GADAdChoicesView *adChoicesView;
 
-/// Returns an MPGoogleAdMobNativeAdAdapter with GADNativeContentAd.
-- (instancetype)initWithAdMobNativeContentAd:(GADNativeContentAd *)adMobNativeContentAd;
-
-/// Returns an MPGoogleAdMobNativeAdAdapter with GADNativeAppInstallAd.
-- (instancetype)initWithAdMobNativeAppInstallAd:(GADNativeAppInstallAd *)adMobNativeAppInstallAd;
+/// Returns an MPGoogleAdMobNativeAdAdapter with GADUnifiedNativeAd.
+- (instancetype)initWithAdMobUnifiedNativeAd:(GADUnifiedNativeAd *)adMobUnifiedNativeAd;
 
 @end

--- a/AdMob/MPGoogleAdMobNativeAdAdapter.m
+++ b/AdMob/MPGoogleAdMobNativeAdAdapter.m
@@ -15,39 +15,39 @@ static NSString *const kGADMStoreKey = @"store";
 @synthesize properties = _properties;
 @synthesize defaultActionURL = _defaultActionURL;
 
-- (instancetype)initWithAdMobNativeContentAd:(GADNativeContentAd *)adMobNativeContentAd {
+- (instancetype)initWithAdMobUnifiedNativeAd:(GADUnifiedNativeAd *)adMobUnifiedNativeAd {
   if (self = [super init]) {
-    self.adMobNativeContentAd = adMobNativeContentAd;
-    self.adMobNativeContentAd.delegate = self;
+    self.adMobUnifiedNativeAd = adMobUnifiedNativeAd;
+    self.adMobUnifiedNativeAd.delegate = self;
 
     // Initializing adChoicesView with default size of (20, 20).
     _adChoicesView = [[GADAdChoicesView alloc] initWithFrame:CGRectMake(0, 0, 20, 20)];
 
     NSMutableDictionary *properties = [NSMutableDictionary dictionary];
 
-    if (adMobNativeContentAd.headline) {
-      properties[kAdTitleKey] = adMobNativeContentAd.headline;
+    if (adMobUnifiedNativeAd.headline) {
+      properties[kAdTitleKey] = adMobUnifiedNativeAd.headline;
     }
 
-    if (adMobNativeContentAd.body) {
-      properties[kAdTextKey] = adMobNativeContentAd.body;
+    if (adMobUnifiedNativeAd.body) {
+      properties[kAdTextKey] = adMobUnifiedNativeAd.body;
     }
 
-    if (adMobNativeContentAd.callToAction) {
-      properties[kAdCTATextKey] = adMobNativeContentAd.callToAction;
+    if (adMobUnifiedNativeAd.callToAction) {
+      properties[kAdCTATextKey] = adMobUnifiedNativeAd.callToAction;
     }
 
-    GADNativeAdImage *mainImage = (GADNativeAdImage *)adMobNativeContentAd.images.firstObject;
+    GADNativeAdImage *mainImage = (GADNativeAdImage *)adMobUnifiedNativeAd.images.firstObject;
     if ([mainImage.imageURL absoluteString]) {
       properties[kAdMainImageKey] = mainImage.imageURL.absoluteString;
     }
 
-    if (adMobNativeContentAd.logo.image) {
-      properties[kAdIconImageKey] = adMobNativeContentAd.logo.image;
+    if (adMobUnifiedNativeAd.icon.image) {
+      properties[kAdIconImageKey] = adMobUnifiedNativeAd.icon.image;
     }
 
-    if (adMobNativeContentAd.advertiser) {
-      properties[kGADMAdvertiserKey] = adMobNativeContentAd.advertiser;
+    if (adMobUnifiedNativeAd.advertiser) {
+      properties[kGADMAdvertiserKey] = adMobUnifiedNativeAd.advertiser;
     }
 
     _properties = properties;
@@ -56,63 +56,14 @@ static NSString *const kGADMStoreKey = @"store";
   return self;
 }
 
-- (instancetype)initWithAdMobNativeAppInstallAd:(GADNativeAppInstallAd *)adMobNativeAppInstallAd {
-  if (self = [super init]) {
-    self.adMobNativeAppInstallAd = adMobNativeAppInstallAd;
-    self.adMobNativeAppInstallAd.delegate = self;
+#pragma mark - <GADUnifiedNativeAdDelegate>
 
-    // Initializing adChoicesView with default size of (20, 20).
-    _adChoicesView = [[GADAdChoicesView alloc] initWithFrame:CGRectMake(0, 0, 20, 20)];
-
-    NSMutableDictionary *properties = [NSMutableDictionary dictionary];
-
-    if (adMobNativeAppInstallAd.headline) {
-      properties[kAdTitleKey] = adMobNativeAppInstallAd.headline;
-    }
-
-    GADNativeAdImage *mainImage = (GADNativeAdImage *)adMobNativeAppInstallAd.images.firstObject;
-    if ([mainImage.imageURL absoluteString]) {
-      properties[kAdMainImageKey] = mainImage.imageURL.absoluteString;
-    }
-
-    if ([adMobNativeAppInstallAd.icon.imageURL absoluteString]) {
-      properties[kAdIconImageKey] = adMobNativeAppInstallAd.icon.imageURL.absoluteString;
-    }
-
-    if (adMobNativeAppInstallAd.body) {
-      properties[kAdTextKey] = adMobNativeAppInstallAd.body;
-    }
-
-    if (adMobNativeAppInstallAd.starRating) {
-      properties[kAdStarRatingKey] = adMobNativeAppInstallAd.starRating;
-    }
-
-    if (adMobNativeAppInstallAd.callToAction) {
-      properties[kAdCTATextKey] = adMobNativeAppInstallAd.callToAction;
-    }
-
-    if (adMobNativeAppInstallAd.price) {
-      properties[kGADMPriceKey] = adMobNativeAppInstallAd.price;
-    }
-
-    if (adMobNativeAppInstallAd.store) {
-      properties[kGADMStoreKey] = adMobNativeAppInstallAd.store;
-    }
-
-    _properties = properties;
-  }
-
-  return self;
-}
-
-#pragma mark - <GADNativeAdDelegate>
-
-- (void)nativeAdDidRecordImpression:(GADNativeAd *)nativeAd {
+- (void)nativeAdDidRecordImpression:(GADUnifiedNativeAd *)nativeAd {
   // Sending impression to MoPub SDK.
   [self.delegate nativeAdWillLogImpression:self];
 }
 
-- (void)nativeAdDidRecordClick:(GADNativeAd *)nativeAd {
+- (void)nativeAdDidRecordClick:(GADUnifiedNativeAd *)nativeAd {
   // Sending click to MoPub SDK.
   [self.delegate nativeAdDidClick:self];
 }

--- a/AdMob/MPGoogleAdMobNativeRenderer.m
+++ b/AdMob/MPGoogleAdMobNativeRenderer.m
@@ -32,8 +32,8 @@
 /// Class of renderingViewClass.
 @property(nonatomic, strong) Class renderingViewClass;
 
-/// GADNativeAppInstallAdView instance.
-@property(nonatomic, strong) GADNativeAppInstallAdView *appInstallAdView;
+/// GADUnifiedNativeAdView instance.
+@property(nonatomic, strong) GADUnifiedNativeAdView *nativeAdView;
 
 @end
 
@@ -90,31 +90,28 @@
     
     self.adView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     
-    if (self.adapter.adMobNativeAppInstallAd) {
-        [self renderAppInstallAdViewWithAdapter:self.adapter];
-    } else {
-        [self renderContentAdViewWithAdapter:self.adapter];
-    }
+    [self renderUnifiedNativeAdViewWithAdapter:self.adapter];
     
     return self.adView;
 }
 
-/// Creates native app install ad view with adapter. We added GADNativeAppInstallAdView assets on
+/// Creates unified native ad view with adapter. We added GADUnifiedNativeAdView assets on
 /// top of MoPub's adView, to track impressions & clicks.
-- (void)renderAppInstallAdViewWithAdapter:(id<MPNativeAdAdapter>)adapter {
-    // We only load text here. We're creating the GADNativeAppInstallAdView and preparing text
+- (void)renderUnifiedNativeAdViewWithAdapter:(id<MPNativeAdAdapter>)adapter {
+    // We only load text here. We're creating the GADUnifiedNativeAdView and preparing text
     // assets.
-    GADNativeAppInstallAdView *gadAppInstallAdView = [[GADNativeAppInstallAdView alloc] init];
-    [self.adView addSubview:gadAppInstallAdView];
-    [gadAppInstallAdView gad_fillSuperview];
+    GADUnifiedNativeAdView *gadUnifiedNativeAdView = [[GADUnifiedNativeAdView alloc] init];
+    [self.adView addSubview:gadUnifiedNativeAdView];
+    [gadUnifiedNativeAdView gad_fillSuperview];
     
-    gadAppInstallAdView.adChoicesView = (GADAdChoicesView *)[self.adapter privacyInformationIconView];
-    gadAppInstallAdView.nativeAppInstallAd = self.adapter.adMobNativeAppInstallAd;
+    gadUnifiedNativeAdView.adChoicesView = (GADAdChoicesView *)[self.adapter privacyInformationIconView];
+    gadUnifiedNativeAdView.nativeAd = self.adapter.adMobUnifiedNativeAd;
+    
     if ([self.adView respondsToSelector:@selector(nativeTitleTextLabel)]) {
         UILabel *headlineView = [[UILabel alloc] initWithFrame:CGRectZero];
-        headlineView.text = self.adapter.adMobNativeAppInstallAd.headline;
+        headlineView.text = self.adapter.adMobUnifiedNativeAd.headline;
         headlineView.textColor = [UIColor clearColor];
-        gadAppInstallAdView.headlineView = headlineView;
+        gadUnifiedNativeAdView.headlineView = headlineView;
         [self.adView.nativeTitleTextLabel addSubview:headlineView];
         [headlineView gad_fillSuperview];
         self.adView.nativeTitleTextLabel.text = adapter.properties[kAdTitleKey];
@@ -122,9 +119,9 @@
     
     if ([self.adView respondsToSelector:@selector(nativeMainTextLabel)]) {
         UILabel *bodyView = [[UILabel alloc] initWithFrame:CGRectZero];
-        bodyView.text = self.adapter.adMobNativeAppInstallAd.body;
+        bodyView.text = self.adapter.adMobUnifiedNativeAd.body;
         bodyView.textColor = [UIColor clearColor];
-        gadAppInstallAdView.bodyView = bodyView;
+        gadUnifiedNativeAdView.bodyView = bodyView;
         [self.adView.nativeMainTextLabel addSubview:bodyView];
         [bodyView gad_fillSuperview];
         self.adView.nativeMainTextLabel.text = adapter.properties[kAdTextKey];
@@ -133,9 +130,9 @@
     if ([self.adView respondsToSelector:@selector(nativeCallToActionTextLabel)] &&
         self.adView.nativeCallToActionTextLabel) {
         UILabel *callToActionView = [[UILabel alloc] initWithFrame:CGRectZero];
-        callToActionView.text = self.adapter.adMobNativeAppInstallAd.callToAction;
+        callToActionView.text = self.adapter.adMobUnifiedNativeAd.callToAction;
         callToActionView.textColor = [UIColor clearColor];
-        gadAppInstallAdView.callToActionView = callToActionView;
+        gadUnifiedNativeAdView.callToActionView = callToActionView;
         [self.adView.nativeCallToActionTextLabel addSubview:callToActionView];
         [callToActionView gad_fillSuperview];
         self.adView.nativeCallToActionTextLabel.text = adapter.properties[kAdCTATextKey];
@@ -150,7 +147,7 @@
         [[GADNativeAdImage alloc] initWithURL:[NSURL URLWithString:mainImageURLString] scale:1];
         UIImageView *mainMediaImageView = [[UIImageView alloc] initWithFrame:CGRectZero];
         mainMediaImageView.image = nativeAdImage.image;
-        gadAppInstallAdView.imageView = mainMediaImageView;
+        gadUnifiedNativeAdView.imageView = mainMediaImageView;
         [self.adView.nativeMainImageView addSubview:mainMediaImageView];
         [mainMediaImageView gad_fillSuperview];
     }
@@ -161,7 +158,7 @@
         [[GADNativeAdImage alloc] initWithURL:[NSURL URLWithString:iconImageURLString] scale:1];
         UIImageView *iconView = [[UIImageView alloc] initWithFrame:CGRectZero];
         iconView.image = nativeAdImage.image;
-        gadAppInstallAdView.iconView = iconView;
+        gadUnifiedNativeAdView.iconView = iconView;
         [self.adView.nativeIconImageView addSubview:iconView];
         [iconView gad_fillSuperview];
     }
@@ -180,81 +177,7 @@
     // as its subview if it does.
     if ([self.adView respondsToSelector:@selector(nativePrivacyInformationIconImageView)]) {
         [self.adView.nativePrivacyInformationIconImageView
-         addSubview:gadAppInstallAdView.adChoicesView];
-    }
-}
-
-/// Creates native app content ad view with adapter. We added GADNativeContentAdView assets on top
-/// of MoPub's adView, to track impressions & clicks.
-- (void)renderContentAdViewWithAdapter:(id<MPNativeAdAdapter>)adapter {
-    // We only load text here. We're creating the GADNativeContentAdView and preparing text assets.
-    GADNativeContentAdView *gadAppContentAdView = [[GADNativeContentAdView alloc] init];
-    [self.adView addSubview:gadAppContentAdView];
-    [gadAppContentAdView gad_fillSuperview];
-    
-    gadAppContentAdView.adChoicesView = (GADAdChoicesView *)[self.adapter privacyInformationIconView];
-    gadAppContentAdView.nativeContentAd = self.adapter.adMobNativeContentAd;
-    if ([self.adView respondsToSelector:@selector(nativeTitleTextLabel)]) {
-        UILabel *headlineView = [[UILabel alloc] initWithFrame:CGRectZero];
-        headlineView.text = self.adapter.adMobNativeContentAd.headline;
-        headlineView.textColor = [UIColor clearColor];
-        gadAppContentAdView.headlineView = headlineView;
-        [self.adView.nativeTitleTextLabel addSubview:headlineView];
-        [headlineView gad_fillSuperview];
-        self.adView.nativeTitleTextLabel.text = adapter.properties[kAdTitleKey];
-    }
-    
-    if ([self.adView respondsToSelector:@selector(nativeMainTextLabel)]) {
-        UILabel *bodyView = [[UILabel alloc] initWithFrame:CGRectZero];
-        bodyView.text = self.adapter.adMobNativeContentAd.body;
-        bodyView.textColor = [UIColor clearColor];
-        gadAppContentAdView.bodyView = bodyView;
-        [self.adView.nativeMainTextLabel addSubview:bodyView];
-        [bodyView gad_fillSuperview];
-        self.adView.nativeMainTextLabel.text = adapter.properties[kAdTextKey];
-    }
-    
-    if ([self.adView respondsToSelector:@selector(nativeCallToActionTextLabel)] &&
-        self.adView.nativeCallToActionTextLabel) {
-        UILabel *callToActionView = [[UILabel alloc] initWithFrame:CGRectZero];
-        callToActionView.text = self.adapter.adMobNativeContentAd.callToAction;
-        callToActionView.textColor = [UIColor clearColor];
-        gadAppContentAdView.callToActionView = callToActionView;
-        [self.adView.nativeCallToActionTextLabel addSubview:callToActionView];
-        [callToActionView gad_fillSuperview];
-        self.adView.nativeCallToActionTextLabel.text = adapter.properties[kAdCTATextKey];
-    }
-    
-    // We delay loading of images until the view is added to the view hierarchy so we don't
-    // unnecessarily load images from the cache if the user is scrolling fast. So we will just store
-    // the image URLs for now.
-    if ([self.adView respondsToSelector:@selector(nativeMainImageView)]) {
-        NSString *mainImageURLString = adapter.properties[kAdMainImageKey];
-        GADNativeAdImage *nativeAdImage =
-        [[GADNativeAdImage alloc] initWithURL:[NSURL URLWithString:mainImageURLString] scale:1];
-        UIImageView *mainMediaImageView = [[UIImageView alloc] initWithFrame:CGRectZero];
-        mainMediaImageView.image = nativeAdImage.image;
-        gadAppContentAdView.imageView = mainMediaImageView;
-        [self.adView.nativeMainImageView addSubview:mainMediaImageView];
-        [mainMediaImageView gad_fillSuperview];
-    }
-    
-    if ([self.adView respondsToSelector:@selector(nativeIconImageView)]) {
-        NSString *iconImageURLString = adapter.properties[kAdIconImageKey];
-        GADNativeAdImage *nativeAdImage =
-        [[GADNativeAdImage alloc] initWithURL:[NSURL URLWithString:iconImageURLString] scale:1];
-        UIImageView *iconView = [[UIImageView alloc] initWithFrame:CGRectZero];
-        iconView.image = nativeAdImage.image;
-        gadAppContentAdView.logoView = iconView;
-        [self.adView.nativeIconImageView addSubview:iconView];
-        [iconView gad_fillSuperview];
-    }
-    
-    // See if the ad contains the nativePrivacyInformationIconImageView and add GADAdChoices view
-    // as its subview if it does.
-    if ([self.adView respondsToSelector:@selector(nativePrivacyInformationIconImageView)]) {
-        [self.adView.nativePrivacyInformationIconImageView
-         addSubview:gadAppContentAdView.adChoicesView];
+         addSubview:gadUnifiedNativeAdView.adChoicesView];
     }
 }
 


### PR DESCRIPTION
Using GADUnifiedNativeAd in place of deprecated classes

https://developers.google.com/admob/ios/rel-notes - Under 7.32.0:

“Native ads: GADNativeAppInstallAd, GADNativeContentAd, and associated APIs are deprecated in favor of GADUnifiedNativeAd.”
