### PR TITLE
AdMob interstitial to use initWithAdUnitID - 7.32.0.1

### DIFF
--- a/AdMob/CHANGELOG.md
+++ b/AdMob/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Changelog
+  * 7.32.0.1
+    * The interstitial adapter now uses `initWithAdUnitID` instead of specifying the `adUnitID` property, since that is now read-only.
+
   * 7.32.0.0
     * This version of the adapters has been certified with AdMob 7.32.0.
 

--- a/AdMob/MPGoogleAdMobInterstitialCustomEvent.m
+++ b/AdMob/MPGoogleAdMobInterstitialCustomEvent.m
@@ -28,9 +28,8 @@
 - (void)requestInterstitialWithCustomEventInfo:(NSDictionary *)info
 {
     MPLogInfo(@"Requesting Google AdMob interstitial");
-    self.interstitial = [[GADInterstitial alloc] init];
-
-    self.interstitial.adUnitID = [info objectForKey:@"adUnitID"];
+    NSString *adUnitId = [info objectForKey:@"adUnitID"];
+    self.interstitial = [[GADInterstitial alloc] initWithAdUnitID:adUnitId];
     self.interstitial.delegate = self;
 
     GADRequest *request = [GADRequest request];

--- a/AdMob/MoPub-AdMob-PodSpecs/MoPub-AdMob-Adapters.podspec
+++ b/AdMob/MoPub-AdMob-PodSpecs/MoPub-AdMob-Adapters.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
 s.name             = 'MoPub-AdMob-Adapters'
-s.version          = '7.32.0.0'
+s.version          = '7.32.0.1'
 s.summary          = 'Google Adapters for mediating through MoPub.'
 s.description      = <<-DESC
 Supported ad formats: Banner, Interstitial, Rewarded Video, Native.\n


### PR DESCRIPTION
Does the same as https://github.com/mopub/mopub-ios-mediation/pull/87.