### PR TITLE
Certify FB adapters - 5.0.0.0

### DIFF
--- a/FacebookAudienceNetwork/CHANGELOG.md
+++ b/FacebookAudienceNetwork/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Changelog
+* 5.0.0.0
+    * This version of the adapters has been certified with Facebook Audience Network 5.0.0.
+    * Remove calls to disableAutoRefresh for banner (deprecated by Facebook).
+
 * 4.99.2.1
     * Align MoPub's interstitial impression tracking to that of Facebook Audience Network.
         * Automatic impression tracking is disabled, and Facebook's `interstitialAdWillLogImpression` is used to fire MoPub impressions.

--- a/FacebookAudienceNetwork/CHANGELOG.md
+++ b/FacebookAudienceNetwork/CHANGELOG.md
@@ -2,7 +2,7 @@
 * 5.0.0.0
     * This version of the adapters has been certified with Facebook Audience Network 5.0.0.
     * Remove calls to disableAutoRefresh for banner (deprecated by Facebook).
-    * Expose the native ad's advertiser name asset for publishers to show as required by Facebook (https://developers.facebook.com/docs/audience-network/guidelines/native-ads#name).
+    * Enable publishers to use the advertiser name asset as it is a required asset starting in Facebook 4.99.0 (https://developers.facebook.com/docs/audience-network/guidelines/native-ads#name).
 
 * 4.99.2.1
     * Align MoPub's interstitial impression tracking to that of Facebook Audience Network.

--- a/FacebookAudienceNetwork/CHANGELOG.md
+++ b/FacebookAudienceNetwork/CHANGELOG.md
@@ -2,6 +2,7 @@
 * 5.0.0.0
     * This version of the adapters has been certified with Facebook Audience Network 5.0.0.
     * Remove calls to disableAutoRefresh for banner (deprecated by Facebook).
+    * Expose the native ad's advertiser name asset for publishers to show as required by Facebook (https://developers.facebook.com/docs/audience-network/guidelines/native-ads#name).
 
 * 4.99.2.1
     * Align MoPub's interstitial impression tracking to that of Facebook Audience Network.

--- a/FacebookAudienceNetwork/FacebookBannerCustomEvent.m
+++ b/FacebookAudienceNetwork/FacebookBannerCustomEvent.m
@@ -61,7 +61,6 @@
                                                    adSize:fbAdSize
                                        rootViewController:[self.delegate viewControllerForPresentingModalView]];
     self.fbAdView.delegate = self;
-    [self.fbAdView disableAutoRefresh];
 
     if (!self.fbAdView) {
         [self.delegate bannerCustomEvent:self didFailToLoadAdWithError:nil];

--- a/FacebookAudienceNetwork/FacebookNativeAdAdapter.m
+++ b/FacebookAudienceNetwork/FacebookNativeAdAdapter.m
@@ -55,6 +55,13 @@ NSString *const kFBVideoAdsEnabledKey = @"video_enabled";
             [properties setObject:fbNativeAd.callToAction forKey:kAdCTATextKey];
         }
         
+        /* Per Facebook's requirements, either the ad title or the advertiser name
+        will be displayed, depending on the FB SDK version. Therefore, mapping both
+        to the MoPub's ad title asset */
+        if (fbNativeAd.advertiserName) {
+            [properties setObject:fbNativeAd.advertiserName forKey:kAdTitleKey];
+        }
+        
         [properties setObject:_iconView forKey:kAdIconImageViewKey];
         [properties setObject:_mediaView forKey:kAdMainMediaViewKey];
 

--- a/FacebookAudienceNetwork/FacebookNativeCustomEvent.m
+++ b/FacebookAudienceNetwork/FacebookNativeCustomEvent.m
@@ -56,7 +56,6 @@ static BOOL gVideoEnabled = NO;
             MPLogInfo(@"Loading Facebook native ad markup");
             [self.fbNativeAd loadAdWithBidPayload:adMarkup];
         }
-        // Request a banner ad.
         else {
             MPLogInfo(@"Requesting Facebook native ad");
             [self.fbNativeAd loadAd];

--- a/FacebookAudienceNetwork/MoPub-FacebookAudienceNetwork-Podspecs/MoPub-FacebookAudienceNetwork-Adapters.podspec
+++ b/FacebookAudienceNetwork/MoPub-FacebookAudienceNetwork-Podspecs/MoPub-FacebookAudienceNetwork-Adapters.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
 s.name             = 'MoPub-FacebookAudienceNetwork-Adapters'
-s.version          = '4.99.2.1'
+s.version          = '5.0.0.0'
 s.summary          = 'Facebook Adapters for mediating through MoPub.'
 s.description      = <<-DESC
 Supported ad formats: Banners, Interstitial, Rewarded Video and Native.\n
@@ -20,5 +20,5 @@ s.ios.deployment_target = '8.0'
 s.static_framework = true
 s.source_files = 'FacebookAudienceNetwork/*.{h,m}'
 s.dependency 'mopub-ios-sdk', '~> 5.0'
-s.dependency 'FBAudienceNetwork', '4.99.2'
+s.dependency 'FBAudienceNetwork', '5.0.0'
 end


### PR DESCRIPTION
* Certify with FB Audience Network 5.0.0.
* Remove calls to disableAutoRefresh for banner (deprecated by Facebook).
* Expose the advertiser name asset.