### PR TITLE
Prepare Vungle adapters for release - 6.2.0.2

### DIFF
--- a/Vungle/CHANGELOG.md
+++ b/Vungle/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Changelog
+  * 6.2.0.2
+    * Remove remaining code pertaining to Vungle's placement IDs (`pids`) since it's no longer needed to initialize Vungle.
+
   * 6.2.0.1  
-    * update adapters to remove dependency on MPInstanceProvider
+    * Update adapters to remove dependency on MPInstanceProvider
     * Update adapters to be compatible with MoPub iOS SDK framework
 
   * 6.2.0.0

--- a/Vungle/CHANGELOG.md
+++ b/Vungle/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
   * 6.2.0.2
-    * Remove remaining code pertaining to Vungle's placement IDs (`pids`) since it's no longer needed to initialize Vungle.
+    * Clean up remaining code pertaining to Vungle's placement IDs (`pids`) since it's no longer needed to initialize Vungle.
 
   * 6.2.0.1  
     * Update adapters to remove dependency on MPInstanceProvider

--- a/Vungle/MPVungleRouter.m
+++ b/Vungle/MPVungleRouter.m
@@ -18,7 +18,6 @@ static NSString *const VunglePluginVersion = @"6.2.0";
 
 static NSString *const kVungleAppIdKey = @"appId";
 NSString *const kVunglePlacementIdKey = @"pid";
-static NSString *const kVunglePlacementIdsKey = @"pids";
 NSString *const kVungleFlexViewAutoDismissSeconds = @"flexViewAutoDismissSeconds";
 NSString *const kVungleUserId = @"userId";
 NSString *const kVungleOrdinal = @"ordinal";
@@ -75,10 +74,6 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
     if (!self.vungleAppID) {
         self.vungleAppID = appId;
     }
-
-    NSString *placementIdsString = [[info objectForKey:kVunglePlacementIdsKey] stringByReplacingOccurrencesOfString:@" " withString:@""];
-    if ([placementIdsString length])
-        MPLogInfo(@"No need to set placement IDs in MoPub dashboard with Vungle iOS SDK version %@ and plugin version %@", VungleSDKVersion, VunglePluginVersion);
 
     static dispatch_once_t vungleInitToken;
     dispatch_once(&vungleInitToken, ^{

--- a/Vungle/MoPub-Vungle-PodSpecs/MoPub-Vungle-Adapters.podspec
+++ b/Vungle/MoPub-Vungle-PodSpecs/MoPub-Vungle-Adapters.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
 s.name             = 'MoPub-Vungle-Adapters'
-s.version          = '6.2.0.1'
+s.version          = '6.2.0.2'
 s.summary          = 'Vungle Adapters for mediating through MoPub.'
 s.description      = <<-DESC
 Supported ad formats: Interstitial, Rewarded Video.\n


### PR DESCRIPTION
Remove remaining code pertaining to Vungle's placement IDs (`pids`) since it's no longer needed to initialize Vungle.