### PR TITLE
Fix build error with usage of undefined constants for 5.0.0 FB->Mopub adapter

### DIFF
--- a/FacebookAudienceNetwork/FacebookNativeAdAdapter.m
+++ b/FacebookAudienceNetwork/FacebookNativeAdAdapter.m
@@ -62,8 +62,9 @@ NSString *const kFBVideoAdsEnabledKey = @"video_enabled";
             [properties setObject:fbNativeAd.advertiserName forKey:kAdTitleKey];
         }
         
-        [properties setObject:_iconView forKey:kAdIconImageViewKey];
-        [properties setObject:_mediaView forKey:kAdMainMediaViewKey];
+        if (fbNativeAd.adChoicesIcon.url.absoluteString) {
+            [properties setObject:fbNativeAd.adChoicesIcon.url.absoluteString forKey:kAdIconImageKey];
+        }
 
         if (fbNativeAd.placementID) {
             [properties setObject:fbNativeAd.placementID forKey:@"placementID"];


### PR DESCRIPTION
By looking at usage  of kAdIconImageKey, clearly the caller is expecting a string not an instance of FBAdIconView, also there is no reference to any key for media view, it is rather through the `mainMediaView` method defined in this class