### PR TITLE
Add no_fill detection to Unity Ads adaptor

### DIFF
--- a/UnityAds/CHANGELOG.md
+++ b/UnityAds/CHANGELOG.md
@@ -1,5 +1,8 @@
 
 ## Changelog
+* 2.3.0.1
+  * Handle no-fill scenarios from Unity Ads. 
+
 * 2.3.0.0
   * This version of the adapters has been certified with UnityAds 2.3.0
 

--- a/UnityAds/MPUnityRouter.m
+++ b/UnityAds/MPUnityRouter.m
@@ -164,6 +164,10 @@
     if (delegate != nil && [delegate respondsToSelector:@selector(unityAdsPlacementStateChanged:oldState:newState:)]) {
         [delegate unityAdsPlacementStateChanged:placementId oldState:oldState newState:newState];
     }
+    if (delegate != nil && newState == kUnityAdsPlacementStateNoFill){
+        NSError *error = [NSError errorWithDomain:MoPubRewardedVideoAdsSDKDomain code:MPRewardedVideoAdErrorUnknown userInfo:nil];
+        [delegate unityAdsDidFailWithError:error];
+    }
 }
 
 @end

--- a/UnityAds/MPUnityRouter.m
+++ b/UnityAds/MPUnityRouter.m
@@ -164,6 +164,7 @@
     if (delegate != nil && [delegate respondsToSelector:@selector(unityAdsPlacementStateChanged:oldState:newState:)]) {
         [delegate unityAdsPlacementStateChanged:placementId oldState:oldState newState:newState];
     }
+    
     if (delegate != nil && newState == kUnityAdsPlacementStateNoFill){
         NSError *error = [NSError errorWithDomain:MoPubRewardedVideoAdsSDKDomain code:MPRewardedVideoAdErrorUnknown userInfo:nil];
         [delegate unityAdsDidFailWithError:error];

--- a/UnityAds/MoPub-UnityAds-PodSpecs/MoPub-UnityAds-Adapters.podspec
+++ b/UnityAds/MoPub-UnityAds-PodSpecs/MoPub-UnityAds-Adapters.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
 s.name             = 'MoPub-UnityAds-Adapters'
-s.version          = '2.3.0.0'
+s.version          = '2.3.0.1'
 s.summary          = 'Unity Adapters for mediating through MoPub.'
 s.description      = <<-DESC
 Supported ad formats: Interstitial, Rewarded Video.\n


### PR DESCRIPTION
Make the Unity Ads router throw an error to the delegate when no_fill is detected.
This should properly notify the Mopub SDK in a no_fill scenario, and improve the 30 second timeout behavior