### PR TITLE
Add new Chartboost GDPR method, remove deprecated one

### DIFF
--- a/Chartboost/CHANGELOG.md
+++ b/Chartboost/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Changelog
+  * 7.3.0.0
+      * Use Chartboost's `setPIDataUseConsent` instead of `restrictDataCollection` to pass GDPR consent data per Chartboost's 7.3.0 release.
+
   * 7.2.0.3
       * Override Chartboost's didDismissRewardedVideo callback 
       * Adapters now explicitly cache ads instead of calling Chartboost SDK's `setAutoCacheAds` to avoid request tracking issues.

--- a/Chartboost/MPChartboostRouter.m
+++ b/Chartboost/MPChartboostRouter.m
@@ -63,7 +63,7 @@
         // Collect and pass the user's consent from MoPub onto the Chartboost SDK
         if ([[MoPub sharedInstance] isGDPRApplicable] == MPBoolYes) {
             BOOL canCollectPersonalInfo = [[MoPub sharedInstance] canCollectPersonalInfo];
-            [Chartboost restrictDataCollection:!canCollectPersonalInfo];
+            [Chartboost setPIDataUseConsent:canCollectPersonalInfo ? YesBehavioral : NoBehavioral];
         }
         
         self.activeInterstitialLocations = [NSMutableSet set];

--- a/Chartboost/MoPub-Chartboost-PodSpecs/MoPub-Chartboost-Adapters.podspec
+++ b/Chartboost/MoPub-Chartboost-PodSpecs/MoPub-Chartboost-Adapters.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
 s.name             = 'MoPub-Chartboost-Adapters'
-s.version          = '7.2.0.3'
+s.version          = '7.3.0.0'
 s.summary          = 'Chartboost Adapters for mediating through MoPub.'
 s.description      = <<-DESC
 Supported ad formats: Interstitial, Rewarded Video.\n
@@ -20,5 +20,5 @@ s.ios.deployment_target = '8.0'
 s.static_framework = true
 s.source_files = 'Chartboost/*.{h,m}'
 s.dependency 'mopub-ios-sdk', '~> 5.0'
-s.dependency 'ChartboostSDK', '7.2.0'
+s.dependency 'ChartboostSDK', '7.3.0'
 end


### PR DESCRIPTION
Chartboost GDPR control method changed from

> + (void)restrictDataCollection:(BOOL)shouldRestrict

to 

> + (void)setPIDataUseConsent:(CBPIDataUseConsent)consent;