### PR TITLE
Prepare Flurry adapters for release - 9.2.0.0

### DIFF
--- a/Flurry/CHANGELOG.md
+++ b/Flurry/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Changelog
+  * 9.2.0.0
+    * This version of the adapters has been certified with Flurry 9.2.0.
+
   * 9.0.0.0
     * This version of the adapters has been certified with Flurry 9.0.0.
 

--- a/Flurry/FlurryMPConfig.m
+++ b/Flurry/FlurryMPConfig.m
@@ -15,7 +15,7 @@
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         if (![Flurry activeSessionExists]) {
-            [Flurry setDebugLogEnabled:YES];
+            [Flurry setLogLevel:FlurryLogLevelDebug];
             [Flurry startSession:apiKey];
         }
         [Flurry addOrigin:FlurryMediationOrigin withVersion:FlurryAdapterVersion];

--- a/Flurry/MoPub-Flurry-PodSpecs/MoPub-Flurry-Adapters.podspec
+++ b/Flurry/MoPub-Flurry-PodSpecs/MoPub-Flurry-Adapters.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
 s.name             = 'MoPub-Flurry-Adapters'
-s.version          = '9.0.0.0'
+s.version          = '9.2.0.0'
 s.summary          = 'Flurry Adapters for mediating through MoPub.'
 s.description      = <<-DESC
 Supported ad formats:  Interstitial, Rewarded Video, Native.\n
@@ -20,6 +20,6 @@ s.ios.deployment_target = '8.0'
 s.static_framework = true
 s.source_files = 'Flurry/*.{h,m}'
 s.dependency 'mopub-ios-sdk', '~> 5.0'
-s.dependency 'Flurry-iOS-SDK/FlurrySDK', '9.0.0'
-s.dependency 'Flurry-iOS-SDK/FlurryAds', '9.0.0'
+s.dependency 'Flurry-iOS-SDK/FlurrySDK', '9.2.0'
+s.dependency 'Flurry-iOS-SDK/FlurryAds', '9.2.0'
 end


### PR DESCRIPTION
* Certify with Flurry 9.2.0
* Replace `setDebugLogEnabled`, which was deprecated, with `setLogLevel:FlurryLogLevelDebug`