### PR TITLE
Adds Banner support for UnityAds

### DIFF
--- a/UnityAds/CHANGELOG.md
+++ b/UnityAds/CHANGELOG.md
@@ -1,5 +1,9 @@
 
 ## Changelog
+* 3.0.0.0
+  * This version of the adapters has been certified with UnityAds 3.0.0.
+  * Add support for banner ad.
+
 * 2.3.0.1
   * Handle no-fill scenarios from Unity Ads. 
 

--- a/UnityAds/CHANGELOG.md
+++ b/UnityAds/CHANGELOG.md
@@ -3,6 +3,7 @@
 * 3.0.0.0
   * This version of the adapters has been certified with UnityAds 3.0.0.
   * Add support for banner ad.
+  * Update GDPR consent passing logic to use MoPub's `isGDPRApplicable` and `canCollectPersonalInfo`.
 
 * 2.3.0.1
   * Handle no-fill scenarios from Unity Ads. 

--- a/UnityAds/MPUnityRouter.h
+++ b/UnityAds/MPUnityRouter.h
@@ -8,20 +8,20 @@
 #import <Foundation/Foundation.h>
 #import <UnityAds/UnityAds.h>
 #import <UnityAds/UnityAdsExtended.h>
+#import <UnityAds/UADSBanner.h>
 
 @protocol MPUnityRouterDelegate;
 @class UnityAdsInstanceMediationSettings;
 
-@interface MPUnityRouter : NSObject <UnityAdsExtendedDelegate>
+@interface MPUnityRouter : NSObject <UnityAdsExtendedDelegate, UnityAdsBannerDelegate>
 
-@property (nonatomic, weak) id<MPUnityRouterDelegate> delegate;
-@property NSMutableDictionary* delegateMap;
 @property NSString* currentPlacementId;
 
 + (MPUnityRouter *)sharedRouter;
 
 - (void)initializeWithGameId:(NSString *)gameId;
 - (void)requestVideoAdWithGameId:(NSString *)gameId placementId:(NSString *)placementId delegate:(id<MPUnityRouterDelegate>)delegate;
+- (void)requestBannerAdWithGameId:(NSString *)gameId placementId:(NSString *)placementId delegate:(id<UnityAdsBannerDelegate>)delegate;
 - (BOOL)isAdAvailableForPlacementId:(NSString *)placementId;
 - (void)presentVideoAdFromViewController:(UIViewController *)viewController customerId:(NSString *)customerId placementId:(NSString *)placementId settings:(UnityAdsInstanceMediationSettings *)settings delegate:(id<MPUnityRouterDelegate>)delegate;
 - (void)clearDelegate:(id<MPUnityRouterDelegate>)delegate;

--- a/UnityAds/MPUnityRouter.m
+++ b/UnityAds/MPUnityRouter.m
@@ -21,6 +21,13 @@
 @interface MPUnityRouter ()
 
 @property (nonatomic, assign) BOOL isAdPlaying;
+@property (nonatomic, weak) id<MPUnityRouterDelegate> delegate;
+
+@property NSMutableDictionary* delegateMap;
+@property id<UnityAdsBannerDelegate> bannerDelegate;
+
+@property BOOL bannerLoadRequested;
+@property NSString* bannerPlacementId;
 
 @end
 
@@ -51,12 +58,12 @@
         [mediationMetaData setName:@"MoPub"];
         [mediationMetaData setVersion:[[MoPub sharedInstance] version]];
         [mediationMetaData commit];
+        [UnityAdsBanner setDelegate:self];
         [UnityAds initialize:gameId delegate:self];
     });
 }
 
-- (void)requestVideoAdWithGameId:(NSString *)gameId placementId:(NSString *)placementId delegate:(id<MPUnityRouterDelegate>)delegate;
-{
+-(void)updateConsentStatus {
     // Collect and pass the user's consent/non-consent from MoPub to the Unity Ads SDK
     if ([[MoPub sharedInstance] currentConsentStatus] == MPConsentStatusConsented || [[MoPub sharedInstance] currentConsentStatus] == MPConsentStatusDenied) {
         UADSMetaData *gdprConsentMetaData = [[UADSMetaData alloc] init];
@@ -72,7 +79,11 @@
 
         [gdprConsentMetaData commit];
     }
+}
 
+- (void)requestVideoAdWithGameId:(NSString *)gameId placementId:(NSString *)placementId delegate:(id<MPUnityRouterDelegate>)delegate;
+{
+    [self updateConsentStatus];
     if (!self.isAdPlaying) {
         [self.delegateMap setObject:delegate forKey:placementId];
         [self initializeWithGameId:gameId];
@@ -85,6 +96,19 @@
     } else {
         NSError *error = [NSError errorWithDomain:MoPubRewardedVideoAdsSDKDomain code:MPRewardedVideoAdErrorUnknown userInfo:nil];
         [delegate unityAdsDidFailWithError:error];
+    }
+}
+
+-(void)requestBannerAdWithGameId:(NSString *)gameId placementId:(NSString *)placementId delegate:(id <UnityAdsBannerDelegate>)delegate {
+    [self updateConsentStatus];
+    [self initializeWithGameId:gameId];
+    self.bannerDelegate = delegate;
+
+    if ([UnityAds isReady:placementId]) {
+        [UnityAdsBanner loadBanner:placementId];
+    } else {
+        self.bannerLoadRequested = YES;
+        self.bannerPlacementId = placementId;
     }
 }
 
@@ -117,11 +141,20 @@
     }
 }
 
+-(void)clearBannerDelegate {
+    self.bannerDelegate = nil;
+    self.bannerPlacementId = nil;
+    self.bannerLoadRequested = NO;
+}
+
 #pragma mark - UnityAdsExtendedDelegate
 
 - (void)unityAdsReady:(NSString *)placementId
 {
-    if (!self.isAdPlaying) {
+    if ([placementId isEqualToString:self.bannerPlacementId] && self.bannerLoadRequested) {
+        self.bannerLoadRequested = NO;
+        [UnityAdsBanner loadBanner:self.bannerPlacementId];
+    } else if (!self.isAdPlaying) {
         id delegate = [self getDelegate:placementId];
         if (delegate != nil) {
             [delegate unityAdsReady:placementId];
@@ -169,6 +202,28 @@
         NSError *error = [NSError errorWithDomain:MoPubRewardedVideoAdsSDKDomain code:MPRewardedVideoAdErrorUnknown userInfo:nil];
         [delegate unityAdsDidFailWithError:error];
     }
+}
+
+#pragma mark - UnityAdsBannerDelegate
+
+-(void)unityAdsBannerDidLoad:(NSString *)placementId view:(UIView *)view {
+    [self.bannerDelegate unityAdsBannerDidLoad:placementId view:view];
+}
+
+-(void)unityAdsBannerDidUnload:(NSString *)placementId {
+    [self.bannerDelegate unityAdsBannerDidUnload:placementId];
+}
+-(void)unityAdsBannerDidShow:(NSString *)placementId {
+    [self.bannerDelegate unityAdsBannerDidShow:placementId];
+}
+-(void)unityAdsBannerDidHide:(NSString *)placementId {
+    [self.bannerDelegate unityAdsBannerDidHide:placementId];
+}
+-(void)unityAdsBannerDidClick:(NSString *)placementId {
+    [self.bannerDelegate unityAdsBannerDidClick:placementId];
+}
+-(void)unityAdsBannerDidError:(NSString *)message {
+    [self.bannerDelegate unityAdsBannerDidError:message];
 }
 
 @end

--- a/UnityAds/MPUnityRouter.m
+++ b/UnityAds/MPUnityRouter.m
@@ -65,7 +65,8 @@
 
 -(void)updateConsentStatus {
     // Collect and pass the user's consent/non-consent from MoPub to the Unity Ads SDK
-    if ([[MoPub sharedInstance] currentConsentStatus] == MPConsentStatusConsented || [[MoPub sharedInstance] currentConsentStatus] == MPConsentStatusDenied) {
+    
+    if ([MoPub sharedInstance].isGDPRApplicable) {
         UADSMetaData *gdprConsentMetaData = [[UADSMetaData alloc] init];
 
         // If personal data can be collected    - pass YES

--- a/UnityAds/MPUnityRouter.m
+++ b/UnityAds/MPUnityRouter.m
@@ -68,9 +68,9 @@
     if ([[MoPub sharedInstance] currentConsentStatus] == MPConsentStatusConsented || [[MoPub sharedInstance] currentConsentStatus] == MPConsentStatusDenied) {
         UADSMetaData *gdprConsentMetaData = [[UADSMetaData alloc] init];
 
-        // If the user consented - pass YES
-        // If the user denied - pass NO
-        if([[MoPub sharedInstance] currentConsentStatus] == MPConsentStatusConsented) {
+        // If personal data can be collected    - pass YES
+        // If personal data cannot be collected - pass NO
+        if([[MoPub sharedInstance] canCollectPersonalInfo]) {
             [gdprConsentMetaData set:@"gdpr.consent" value:@YES];
         }
         else {

--- a/UnityAds/MoPub-UnityAds-PodSpecs/MoPub-UnityAds-Adapters.podspec
+++ b/UnityAds/MoPub-UnityAds-PodSpecs/MoPub-UnityAds-Adapters.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
 s.name             = 'MoPub-UnityAds-Adapters'
-s.version          = '2.3.0.1'
+s.version          = '3.0.0.0'
 s.summary          = 'Unity Adapters for mediating through MoPub.'
 s.description      = <<-DESC
 Supported ad formats: Interstitial, Rewarded Video.\n
@@ -20,6 +20,6 @@ s.ios.deployment_target = '8.0'
 s.static_framework = true
 s.source_files = 'UnityAds/*.{h,m}'
 s.dependency 'mopub-ios-sdk', '~> 5.0'
-s.dependency 'UnityAds', '2.3.0'
+s.dependency 'UnityAds', '3.0.0'
 end
 

--- a/UnityAds/UnityAdsBannerCustomEvent.h
+++ b/UnityAds/UnityAdsBannerCustomEvent.h
@@ -1,0 +1,13 @@
+#import <UnityAds/UADSBanner.h>
+
+#if __has_include(<MoPub/MoPub.h>)
+#import <MoPub/MoPub.h>
+#elif __has_include(<MoPubSDKFramework/MPBannerCustomEvent.h>)
+#import <MoPubSDKFramework/MPBannerCustomEvent.h>
+#else
+#import "MPBannerCustomEvent.h"
+#endif
+
+@interface UnityAdsBannerCustomEvent : MPBannerCustomEvent<UnityAdsBannerDelegate>
+
+@end

--- a/UnityAds/UnityAdsBannerCustomEvent.h
+++ b/UnityAds/UnityAdsBannerCustomEvent.h
@@ -1,11 +1,11 @@
 #import <UnityAds/UADSBanner.h>
 
 #if __has_include(<MoPub/MoPub.h>)
-#import <MoPub/MoPub.h>
-#elif __has_include(<MoPubSDKFramework/MPBannerCustomEvent.h>)
-#import <MoPubSDKFramework/MPBannerCustomEvent.h>
+    #import <MoPub/MoPub.h>
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MoPub.h>
 #else
-#import "MPBannerCustomEvent.h"
+    #import "MPBannerCustomEvent.h"
 #endif
 
 @interface UnityAdsBannerCustomEvent : MPBannerCustomEvent<UnityAdsBannerDelegate>

--- a/UnityAds/UnityAdsBannerCustomEvent.m
+++ b/UnityAds/UnityAdsBannerCustomEvent.m
@@ -5,7 +5,9 @@
 
 #import "UnityAdsBannerCustomEvent.h"
 #import "MPUnityRouter.h"
-#import "MPLogging.h"
+#if __has_include("MoPub.h")
+    #import "MPLogging.h"
+#endif
 
 static NSString *const kMPUnityRewardedVideoGameId = @"gameId";
 static NSString *const kUnityAdsOptionPlacementIdKey = @"placementId";

--- a/UnityAds/UnityAdsBannerCustomEvent.m
+++ b/UnityAds/UnityAdsBannerCustomEvent.m
@@ -9,7 +9,7 @@
     #import "MPLogging.h"
 #endif
 
-static NSString *const kMPUnityRewardedVideoGameId = @"gameId";
+static NSString *const kMPUnityBannerGameId = @"gameId";
 static NSString *const kUnityAdsOptionPlacementIdKey = @"placementId";
 static NSString *const kUnityAdsOptionZoneIdKey = @"zoneId";
 
@@ -31,16 +31,17 @@ static NSString *const kUnityAdsOptionZoneIdKey = @"zoneId";
 }
 
 -(void)requestAdWithSize:(CGSize)size customEventInfo:(NSDictionary *)info {
-    NSString *gameId = info[kMPUnityRewardedVideoGameId];
+    NSString *gameId = info[kMPUnityBannerGameId];
     self.placementId = info[kUnityAdsOptionPlacementIdKey];
     if (self.placementId == nil) {
         self.placementId = info[kUnityAdsOptionZoneIdKey];
     }
-    if (self.placementId == nil) {
-        [self.delegate bannerCustomEvent:self didFailToLoadAdWithError:nil];
-    } else {
-        [[MPUnityRouter sharedRouter] requestBannerAdWithGameId:gameId placementId:self.placementId delegate:self];
+    if (gameId == nil || self.placementId == nil) {
+        [self.delegate bannerCustomEvent:self didFailToLoadAdWithError:[NSError errorWithDomain:MoPubRewardedVideoAdsSDKDomain code:MPRewardedVideoAdErrorInvalidCustomEvent userInfo:@{NSLocalizedDescriptionKey: @"Custom event class data did not contain gameId/placementId.", NSLocalizedRecoverySuggestionErrorKey: @"Update your MoPub custom event class data to contain a valid Unity Ads gameId/placementId."}]];
+        return;
     }
+
+    [[MPUnityRouter sharedRouter] requestBannerAdWithGameId:gameId placementId:self.placementId delegate:self];
 }
 
 #pragma mark - UnityAdsBannerDelegate

--- a/UnityAds/UnityAdsBannerCustomEvent.m
+++ b/UnityAds/UnityAdsBannerCustomEvent.m
@@ -1,0 +1,69 @@
+//
+// Created by Ross Rothenstine on 11/5/18.
+// Copyright (c) 2018 MoPub. All rights reserved.
+//
+
+#import "UnityAdsBannerCustomEvent.h"
+#import "MPUnityRouter.h"
+#import "MPLogging.h"
+
+static NSString *const kMPUnityRewardedVideoGameId = @"gameId";
+static NSString *const kUnityAdsOptionPlacementIdKey = @"placementId";
+static NSString *const kUnityAdsOptionZoneIdKey = @"zoneId";
+
+@interface UnityAdsBannerCustomEvent ()
+@property (nonatomic) NSString* placementId;
+@end
+
+@implementation UnityAdsBannerCustomEvent
+
+-(id)init {
+    if (self = [super init]) {
+
+    }
+    return self;
+}
+
+-(void)dealloc {
+    [UnityAdsBanner destroy];
+}
+
+-(void)requestAdWithSize:(CGSize)size customEventInfo:(NSDictionary *)info {
+    NSString *gameId = info[kMPUnityRewardedVideoGameId];
+    self.placementId = info[kUnityAdsOptionPlacementIdKey];
+    if (self.placementId == nil) {
+        self.placementId = info[kUnityAdsOptionZoneIdKey];
+    }
+    if (self.placementId == nil) {
+        [self.delegate bannerCustomEvent:self didFailToLoadAdWithError:nil];
+    } else {
+        [[MPUnityRouter sharedRouter] requestBannerAdWithGameId:gameId placementId:self.placementId delegate:self];
+    }
+}
+
+#pragma mark - UnityAdsBannerDelegate
+
+-(void)unityAdsBannerDidLoad:(NSString *)placementId view:(UIView *)view {
+    MPLogInfo(@"Unity Banner did load for placement %@", placementId);
+    [self.delegate bannerCustomEvent:self didLoadAd:view];
+}
+
+-(void)unityAdsBannerDidUnload:(NSString *)placementId {
+    MPLogInfo(@"Unity Banner did unload for placement %@", placementId);
+}
+-(void)unityAdsBannerDidShow:(NSString *)placementId {
+    MPLogInfo(@"Unity Banner did show for placement %@", placementId);
+}
+-(void)unityAdsBannerDidHide:(NSString *)placementId {
+    MPLogInfo(@"Unity Banner did hide for placement %@", placementId);
+}
+-(void)unityAdsBannerDidClick:(NSString *)placementId {
+    MPLogInfo(@"Unity Banner did click for placement %@", placementId);
+    [self.delegate bannerCustomEventWillLeaveApplication:self];
+}
+-(void)unityAdsBannerDidError:(NSString *)message {
+    MPLogInfo(@"Unity Banner did error with message: %@", message);
+    [self.delegate bannerCustomEvent:self didFailToLoadAdWithError:nil];
+}
+
+@end

--- a/UnityAds/UnityAdsInterstitialCustomEvent.m
+++ b/UnityAds/UnityAdsInterstitialCustomEvent.m
@@ -6,9 +6,6 @@
 //
 
 #import "UnityAdsInterstitialCustomEvent.h"
-#if __has_include("MoPub.h")
-    #import "MPLogging.h"
-#endif
 #import "UnityAdsInstanceMediationSettings.h"
 #import "MPUnityRouter.h"
 

--- a/UnityAds/UnityAdsInterstitialCustomEvent.m
+++ b/UnityAds/UnityAdsInterstitialCustomEvent.m
@@ -8,6 +8,9 @@
 #import "UnityAdsInterstitialCustomEvent.h"
 #import "UnityAdsInstanceMediationSettings.h"
 #import "MPUnityRouter.h"
+#if __has_include("MoPub.h")
+    #import "MPLogging.h"
+#endif
 
 static NSString *const kMPUnityRewardedVideoGameId = @"gameId";
 static NSString *const kUnityAdsOptionPlacementIdKey = @"placementId";

--- a/UnityAds/UnityAdsInterstitialCustomEvent.m
+++ b/UnityAds/UnityAdsInterstitialCustomEvent.m
@@ -12,7 +12,7 @@
     #import "MPLogging.h"
 #endif
 
-static NSString *const kMPUnityRewardedVideoGameId = @"gameId";
+static NSString *const kMPUnityInterstitialVideoGameId = @"gameId";
 static NSString *const kUnityAdsOptionPlacementIdKey = @"placementId";
 static NSString *const kUnityAdsOptionZoneIdKey = @"zoneId";
 
@@ -32,16 +32,16 @@ static NSString *const kUnityAdsOptionZoneIdKey = @"zoneId";
 
 - (void)requestInterstitialWithCustomEventInfo:(NSDictionary *)info {
     self.loadRequested = YES;
-    NSString *gameId = [info objectForKey:kMPUnityRewardedVideoGameId];
+    NSString *gameId = [info objectForKey:kMPUnityInterstitialVideoGameId];
     self.placementId = [info objectForKey:kUnityAdsOptionPlacementIdKey];
     if (self.placementId == nil) {
         self.placementId = [info objectForKey:kUnityAdsOptionZoneIdKey];
     }
-    if (self.placementId == nil) {
-        [self.delegate interstitialCustomEvent:self didFailToLoadAdWithError:nil];
-    } else {
-        [[MPUnityRouter sharedRouter] requestVideoAdWithGameId:gameId placementId:self.placementId delegate:self];
+    if (gameId == nil || self.placementId == nil) {
+        [self.delegate interstitialCustomEvent:self didFailToLoadAdWithError:[NSError errorWithDomain:MoPubRewardedVideoAdsSDKDomain code:MPRewardedVideoAdErrorInvalidCustomEvent userInfo:@{NSLocalizedDescriptionKey: @"Custom event class data did not contain gameId/placementId.", NSLocalizedRecoverySuggestionErrorKey: @"Update your MoPub custom event class data to contain a valid Unity Ads gameId/placementId."}]];
+        return;
     }
+    [[MPUnityRouter sharedRouter] requestVideoAdWithGameId:gameId placementId:self.placementId delegate:self];
 }
 
 - (BOOL)hasAdAvailable

--- a/UnityAds/UnityAdsRewardedVideoCustomEvent.m
+++ b/UnityAds/UnityAdsRewardedVideoCustomEvent.m
@@ -8,12 +8,6 @@
 #import "UnityAdsRewardedVideoCustomEvent.h"
 #import "UnityAdsInstanceMediationSettings.h"
 #import "MPUnityRouter.h"
-#if __has_include("MoPub.h")
-    #import "MPRewardedVideoReward.h"
-    #import "MPRewardedVideoError.h"
-    #import "MPLogging.h"
-    #import "MPRewardedVideoCustomEvent+Caching.h"
-#endif
 
 static NSString *const kMPUnityRewardedVideoGameId = @"gameId";
 static NSString *const kUnityAdsOptionPlacementIdKey = @"placementId";

--- a/UnityAds/UnityAdsRewardedVideoCustomEvent.m
+++ b/UnityAds/UnityAdsRewardedVideoCustomEvent.m
@@ -8,6 +8,12 @@
 #import "UnityAdsRewardedVideoCustomEvent.h"
 #import "UnityAdsInstanceMediationSettings.h"
 #import "MPUnityRouter.h"
+#if __has_include("MoPub.h")
+    #import "MPRewardedVideoReward.h"
+    #import "MPRewardedVideoError.h"
+    #import "MPLogging.h"
+    #import "MPRewardedVideoCustomEvent+Caching.h"
+#endif
 
 static NSString *const kMPUnityRewardedVideoGameId = @"gameId";
 static NSString *const kUnityAdsOptionPlacementIdKey = @"placementId";


### PR DESCRIPTION
## Description

This PR will add UnityAds Banner support and does some small cleanup to the codebase. Note that UnityAds Banner currently only supports a single banner instance.

## Testing

- iPhone XS 12.0
- iPhone 8+ 11.0