### PR TITLE
FlurryRenderer fix

### DIFF
--- a/Flurry/CHANGELOG.md
+++ b/Flurry/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Changelog
+  * 9.2.1.1
+    * Ensure an exclusive pairing between Flurry's FlurryNativeAdAdapter and FlurryNativeVideoAdRenderer.
+
   * 9.2.1.0
     * This version of the adapters has been certified with Flurry 9.2.1.
 

--- a/Flurry/FlurryNativeVideoAdRenderer.m
+++ b/Flurry/FlurryNativeVideoAdRenderer.m
@@ -63,7 +63,7 @@
 
  - (UIView *)retrieveViewWithAdapter:(id<MPNativeAdAdapter>)adapter error:(NSError *__autoreleasing *)error
 {
-    if (!adapter) {
+    if (!adapter || ![adapter isKindOfClass:[FlurryNativeAdAdapter class]]) {
         if (error) {
             *error = MPNativeAdNSErrorForRenderValueTypeError();
         }

--- a/Flurry/MoPub-Flurry-PodSpecs/MoPub-Flurry-Adapters.podspec
+++ b/Flurry/MoPub-Flurry-PodSpecs/MoPub-Flurry-Adapters.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
 s.name             = 'MoPub-Flurry-Adapters'
-s.version          = '9.2.1.0'
+s.version          = '9.2.1.1'
 s.summary          = 'Flurry Adapters for mediating through MoPub.'
 s.description      = <<-DESC
 Supported ad formats:  Interstitial, Rewarded Video, Native.\n


### PR DESCRIPTION
protect against another adapter being used in FlurryRenderer, which results in crash. This behavior matches the MPGoogleAdMobNativeRenderer

Example stack trace:
`

6 | app | -[FlurryNativeVideoAdRenderer setupVideoView] (FlurryNativeVideoAdRenderer.m:166)
-- | -- | --
7 | app | -[FlurryNativeVideoAdRenderer retrieveViewWithAdapter:error:] (FlurryNativeVideoAdRenderer.m:77)
8 | MoPub | -[MPNativeAd retrieveAdViewWithError:] (MPNativeAd.m:96)
9 | app | __34-[MoPubAdUnit makeNativeAdRequest]_block_invoke (MoPubAdUnit.m:467)
10 | MoPub | __45-[MPNativeAdRequest assignCompletionHandler:]_block_invoke (MPNativeAdRequest.m:131)
11 | MoPub | -[MPNativeAdRequest completeAdRequestWithAdObject:error:] (MPNativeAdRequest.m:249)
12 | MoPub | -[MPNativeAdRequest nativeCustomEvent:didLoadAd:] (MPNativeAdRequest.m:325)
13 | MoPub | __57-[MPMoPubNativeCustomEvent requestAdWithCustomEventInfo:]_block_invoke (MPMoPubNativeCustomEvent.m:42)

`