### PR TITLE
Prepare adapters for release - AppLovin 6.1.4.0

### DIFF
--- a/AppLovin/AppLovinInterstitialCustomEvent.m
+++ b/AppLovin/AppLovinInterstitialCustomEvent.m
@@ -218,7 +218,7 @@ static NSObject *ALGlobalInterstitialAdsLock;
 
 #pragma mark - Utility Methods
 
-+ (alnullable ALAd *)dequeueAdForZoneIdentifier:(NSString *)zoneIdentifier
++ (nullable ALAd *)dequeueAdForZoneIdentifier:(NSString *)zoneIdentifier
 {
     @synchronized ( ALGlobalInterstitialAdsLock )
     {

--- a/AppLovin/CHANGELOG.md
+++ b/AppLovin/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Changelog
+   * 6.1.4.0
+     * This version of the adapters has been certified with AppLovin SDK 6.1.4.
+
    * 5.1.2.1
      * Add support for AppLovin to be an Advanced Bidder on the MoPub platform.
 

--- a/AppLovin/MoPub-Applovin-PodSpecs/MoPub-Applovin-Adapters.podspec
+++ b/AppLovin/MoPub-Applovin-PodSpecs/MoPub-Applovin-Adapters.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'MoPub-Applovin-Adapters'
-  s.version          = '5.1.2.1'
+  s.version          = '6.1.4.0'
   s.summary          = 'Applovin Adapters for mediating through MoPub.'
   s.description      = <<-DESC
 Supported ad formats: Banners, Interstitial, Rewarded Video and Native.\n
@@ -20,5 +20,5 @@ For inquiries and support, please visit https://www.applovin.com/support \n
   s.static_framework = true
   s.source_files = 'Applovin/*.{h,m}'
   s.dependency 'mopub-ios-sdk', '~> 5.0'
-  s.dependency 'AppLovinSDK', '5.1.2'
+  s.dependency 'AppLovinSDK', '6.1.4'
 end


### PR DESCRIPTION
In AppLovin's latest iOS SDK v. 6.1.0, we have removed conditional nullability annotations such as `alnonnull` and `alnullability` which provided backwards compatibility for publishers on < Xcode 6. Thus, this adapter must be updated as well to provide compatibility.