### PR TITLE
Bring correctly adapter version

### DIFF
--- a/AdMob/MoPub-AdMob-PodSpecs/MoPub-AdMob-Adapters.podspec
+++ b/AdMob/MoPub-AdMob-PodSpecs/MoPub-AdMob-Adapters.podspec
@@ -15,7 +15,7 @@ DESC
 s.homepage         = 'https://github.com/mopub/mopub-ios-mediation'
 s.license          = { :type => 'New BSD', :file => 'LICENSE' }
 s.author           = { 'MoPub' => 'support@mopub.com' }
-s.source           = { :git => 'https://github.com/mopub/mopub-ios-mediation.git', :commit => 'master' }
+s.source           = { :git => 'https://github.com/mopub/mopub-ios-mediation.git', :tag => s.version }
 s.ios.deployment_target = '8.0'
 s.static_framework = true
 s.source_files = 'AdMob/*.{h,m}'


### PR DESCRIPTION
source `:commit  => master` always use latest adapter (implement this in others adapters too, and create tags for versions)