### PR TITLE
Facebook adapters release - 5.3.2.1

### DIFF
--- a/FacebookAudienceNetwork/CHANGELOG.md
+++ b/FacebookAudienceNetwork/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Changelog
 * 5.3.2.1
-    * Fix mapping for Native Ads that causes invalid argument exceptions due to invalid url. 
-    * Replaced `FacebookAdapterConfiguration` initialilization logic with the Facebook Audience Network SDK callbacks.
+    * Fix mapping for native ads that causes invalid argument exceptions due to invalid URLs. 
+    * Update the initialilization logic in `FacebookAdapterConfiguration` to have completion callbacks.
 
 * 5.3.2.0
     * This version of the adapters has been certified with Facebook Audience Network 5.3.2.

--- a/FacebookAudienceNetwork/CHANGELOG.md
+++ b/FacebookAudienceNetwork/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Changelog
+* 5.3.2.1
+    * Fix mapping for Native Ads that causes invalid argument exceptions due to invalid url. 
+    * Replaced `FacebookAdapterConfiguration` initialilization logic with the Facebook Audience Network SDK callbacks.
+
 * 5.3.2.0
     * This version of the adapters has been certified with Facebook Audience Network 5.3.2.
     * Removed dependency on `CoreLocation.framework`.

--- a/FacebookAudienceNetwork/FacebookNativeAdRenderer.m
+++ b/FacebookAudienceNetwork/FacebookNativeAdRenderer.m
@@ -103,7 +103,7 @@
     }
     
     if ([self.adView respondsToSelector:@selector(nativePrivacyInformationIconImageView)]) {
-        FBAdOptionsView *adOptionsView = [[FBAdOptionsView alloc] init];
+        FBAdOptionsView *adOptionsView = (FBAdOptionsView *)adapter.privacyInformationIconView;
         adOptionsView.frame = self.adView.nativePrivacyInformationIconImageView.bounds;
         adOptionsView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
         self.adView.nativePrivacyInformationIconImageView.userInteractionEnabled = YES;

--- a/FacebookAudienceNetwork/MoPub-FacebookAudienceNetwork-Podspecs/MoPub-FacebookAudienceNetwork-Adapters.podspec
+++ b/FacebookAudienceNetwork/MoPub-FacebookAudienceNetwork-Podspecs/MoPub-FacebookAudienceNetwork-Adapters.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
 s.name             = 'MoPub-FacebookAudienceNetwork-Adapters'
-s.version          = '5.3.2.0'
+s.version          = '5.3.2.1'
 s.summary          = 'Facebook Adapters for mediating through MoPub.'
 s.description      = <<-DESC
 Supported ad formats: Banners, Interstitial, Rewarded Video and Native.\n


### PR DESCRIPTION
Fixed bug in Native ads with causes crashes in some scenarios.
Replace hardcoded FBSDK version with the value in the header.
Replace adapter initialization logic with FAN SDK initialization callback