### PR TITLE
Feature/didClick Tapjoy_Mopub iOS adapter support

### DIFF
--- a/Tapjoy/CHANGELOG.md
+++ b/Tapjoy/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## Changelog
+  * 12.3.1.0
+    * This version of adapters has been certified with Tapjoy 12.3.1.
+    * Fix misleading logging for ad load success and ad show failure in `TapjoyRewardedVideoCustomEvent`.
+    * Add `didClick` callback support for interstitial and rewarded video ad clicks.
+
   * 12.2.1.0
     * This version of the adapters has been certified with Tapjoy 12.2.1.
     * Pass MoPub's log level to Tapjoy. To adjust Tapjoy's log level via MoPub's log settings, reference the steps on [this page](https://developers.mopub.com/publishers/ios/test/#enable-logging).

--- a/Tapjoy/MoPub-Tapjoy-PodSpecs/MoPub-TapJoy-Adapters.podspec
+++ b/Tapjoy/MoPub-Tapjoy-PodSpecs/MoPub-TapJoy-Adapters.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
 s.name             = 'MoPub-TapJoy-Adapters'
-s.version          = '12.3.0'
+s.version          = '12.3.1.0'
 s.summary          = 'TapJoy Adapters for mediating through MoPub.'
 s.description      = <<-DESC
 Supported ad formats: Interstitial, Rewarded Video.\n
@@ -19,11 +19,11 @@ s.source           = { :git => 'https://github.com/mopub/mopub-ios-mediation.git
 s.ios.deployment_target = '8.0'
 s.static_framework = true
 s.subspec 'MoPub' do |ms|
-  ms.dependency 'mopub-ios-sdk/Core', '~> 5.7.0'
+  ms.dependency 'mopub-ios-sdk/Core', '~> 5.5'
 end
 s.subspec 'Network' do |ns|
   ns.source_files = 'Tapjoy/*.{h,m}'
-  ns.dependency 'TapjoySDK', '12.3.0'
-  ns.dependency 'mopub-ios-sdk/Core', '~> 5.7.0'
+  ns.dependency 'TapjoySDK', '12.3.1'
+  ns.dependency 'mopub-ios-sdk/Core', '~> 5.5'
 end
 end

--- a/Tapjoy/MoPub-Tapjoy-PodSpecs/MoPub-TapJoy-Adapters.podspec
+++ b/Tapjoy/MoPub-Tapjoy-PodSpecs/MoPub-TapJoy-Adapters.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
 s.name             = 'MoPub-TapJoy-Adapters'
-s.version          = '12.2.1.0'
+s.version          = '12.3.0'
 s.summary          = 'TapJoy Adapters for mediating through MoPub.'
 s.description      = <<-DESC
 Supported ad formats: Interstitial, Rewarded Video.\n
@@ -19,11 +19,11 @@ s.source           = { :git => 'https://github.com/mopub/mopub-ios-mediation.git
 s.ios.deployment_target = '8.0'
 s.static_framework = true
 s.subspec 'MoPub' do |ms|
-  ms.dependency 'mopub-ios-sdk/Core', '~> 5.5'
+  ms.dependency 'mopub-ios-sdk/Core', '~> 5.7.0'
 end
 s.subspec 'Network' do |ns|
   ns.source_files = 'Tapjoy/*.{h,m}'
-  ns.dependency 'TapjoySDK', '12.2.1'
-  ns.dependency 'mopub-ios-sdk/Core', '~> 5.5'
+  ns.dependency 'TapjoySDK', '12.3.0'
+  ns.dependency 'mopub-ios-sdk/Core', '~> 5.7.0'
 end
 end

--- a/Tapjoy/TapjoyAdapterConfiguration.m
+++ b/Tapjoy/TapjoyAdapterConfiguration.m
@@ -41,7 +41,7 @@ typedef NS_ENUM(NSInteger, TapjoyAdapterErrorCode) {
 #pragma mark - MPAdapterConfiguration
 
 - (NSString *)adapterVersion {
-    return @"12.2.1.0";
+    return @"12.3.0";
 }
 
 - (NSString *)biddingToken {

--- a/Tapjoy/TapjoyAdapterConfiguration.m
+++ b/Tapjoy/TapjoyAdapterConfiguration.m
@@ -41,7 +41,7 @@ typedef NS_ENUM(NSInteger, TapjoyAdapterErrorCode) {
 #pragma mark - MPAdapterConfiguration
 
 - (NSString *)adapterVersion {
-    return @"12.3.0";
+    return @"12.3.1.0";
 }
 
 - (NSString *)biddingToken {

--- a/Tapjoy/TapjoyInterstitialCustomEvent.m
+++ b/Tapjoy/TapjoyInterstitialCustomEvent.m
@@ -142,6 +142,12 @@
     [self.delegate interstitialCustomEventDidDisappear:self];
 }
 
+- (void)didClick:(TJPlacement*)placement
+{
+    MPLogAdEvent([MPLogEvent adTappedForAdapter:NSStringFromClass(self.class)], self.placementName);
+    [self.delegate interstitialCustomEventDidReceiveTapEvent:self];  
+}
+
 - (void)tjcConnectSuccess:(NSNotification*)notifyObj {
     MPLogInfo(@"Tapjoy connect Succeeded");
     self.isConnecting = NO;

--- a/Tapjoy/TapjoyRewardedVideoCustomEvent.m
+++ b/Tapjoy/TapjoyRewardedVideoCustomEvent.m
@@ -156,16 +156,16 @@
 #pragma mark - TJPlacementDelegate methods
 
 - (void)requestDidSucceed:(TJPlacement *)placement {
-    MPLogAdEvent([MPLogEvent adLoadSuccessForAdapter:NSStringFromClass(self.class)], self.placementName);
     if (!placement.isContentAvailable) {
         NSError *error = [NSError errorWithDomain:MoPubRewardedVideoAdsSDKDomain code:MPRewardedVideoAdErrorNoAdsAvailable userInfo:nil];
-        MPLogAdEvent([MPLogEvent adShowFailedForAdapter:NSStringFromClass(self.class) error:error], self.placementName);
+        MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:error], self.placementName);
         [self.delegate rewardedVideoDidFailToLoadAdForCustomEvent:self error:error];
     }
 }
 
 - (void)contentIsReady:(TJPlacement *)placement {
     MPLogInfo(@"Tapjoy rewarded video content is ready");
+    MPLogAdEvent([MPLogEvent adLoadSuccessForAdapter:NSStringFromClass(self.class)], self.placementName);
     [self.delegate rewardedVideoDidLoadAdForCustomEvent:self];
 }
 
@@ -199,6 +199,7 @@
 #pragma mark Tapjoy Video
 
 - (void)videoDidStart:(TJPlacement *)placement {
+    MPLogAdEvent([MPLogEvent adWillAppearForAdapter:NSStringFromClass(self.class)], self.placement);
 }
 
 - (void)videoDidComplete:(TJPlacement*)placement {
@@ -206,6 +207,7 @@
 }
 
 - (void)videoDidFail:(TJPlacement*)placement error:(NSString*)errorMsg {
+    MPLogAdEvent([MPLogEvent adShowFailedForAdapter:NSStringFromClass(self.class) error:errorMsg], self.placement);
 }
 
 - (void)tjcConnectSuccess:(NSNotification*)notifyObj {

--- a/Tapjoy/TapjoyRewardedVideoCustomEvent.m
+++ b/Tapjoy/TapjoyRewardedVideoCustomEvent.m
@@ -11,7 +11,7 @@
 #endif
 #import "TapjoyGlobalMediationSettings.h"
 
-@interface TapjoyRewardedVideoCustomEvent () <TJPlacementDelegate, TJCVideoAdDelegate>
+@interface TapjoyRewardedVideoCustomEvent () <TJPlacementDelegate, TJPlacementVideoDelegate>
 @property (nonatomic, strong) TJPlacement *placement;
 @property (nonatomic, assign) BOOL isConnecting;
 @property (nonatomic, copy) NSString *placementName;
@@ -175,7 +175,6 @@
 }
 
 - (void)contentDidAppear:(TJPlacement *)placement {
-    [Tapjoy setVideoAdDelegate:self];
     MPLogAdEvent([MPLogEvent adWillAppearForAdapter:NSStringFromClass(self.class)], self.placementName);
     [self.delegate rewardedVideoWillAppearForCustomEvent:self];
     MPLogAdEvent([MPLogEvent adShowSuccessForAdapter:NSStringFromClass(self.class)], self.placementName);
@@ -191,10 +190,22 @@
     [self.delegate rewardedVideoDidDisappearForCustomEvent:self];
 }
 
+- (void)didClick:(TJPlacement*)placement
+{
+    MPLogAdEvent([MPLogEvent adTappedForAdapter:NSStringFromClass(self.class)], self.placementName);
+    [self.delegate rewardedVideoDidReceiveTapEventForCustomEvent:self];
+}
+
 #pragma mark Tapjoy Video
 
-- (void)videoAdCompleted {
+- (void)videoDidStart:(TJPlacement *)placement {
+}
+
+- (void)videoDidComplete:(TJPlacement*)placement {
     [self.delegate rewardedVideoShouldRewardUserForCustomEvent:self reward:[[MPRewardedVideoReward alloc] initWithCurrencyAmount:@(kMPRewardedVideoRewardCurrencyAmountUnspecified)]];
+}
+
+- (void)videoDidFail:(TJPlacement*)placement error:(NSString*)errorMsg {
 }
 
 - (void)tjcConnectSuccess:(NSNotification*)notifyObj {


### PR DESCRIPTION
This PR is regarding` didClick` callback support for Tapjoy adapter for Mopub iOS SDK.  `didClick ` callback will fire when a click event has occurred on Tapjoy placement. 

What's new:
 - (void)didClick:(TJPlacement*)placement is added to TapjoyInterstitialCustomEvent.m and TapjoyRewardedVideoCustomEvent.m classes of Tapjoy iOS adapter.

*Notes: `didClick ` callback  won't get fired or be fully functioning currently until Tapjoy server change is completed near future.

How to test:
- Run MoPub sample app with latest Mopub SDK, Tapjoy SDK and Tapjoy Adapter from this branch.
- Request Tapjoy video placement. 
- Show and play the video ads.
- Perform a click on video ads and observe in Logcat if `didClick` callback gets fired on this placement from Tapjoy Network. 