### PR TITLE
update fetch bidding token API for Tapjoy

### DIFF
--- a/Tapjoy/TapjoyAdapterConfiguration.m
+++ b/Tapjoy/TapjoyAdapterConfiguration.m
@@ -45,8 +45,7 @@ typedef NS_ENUM(NSInteger, TapjoyAdapterErrorCode) {
 }
 
 - (NSString *)biddingToken {
-    NSString *token = [Tapjoy getUserToken];
-    return (token.length > 0 ? token : @"1");
+    return [Tapjoy getUserToken];
 }
 
 - (NSString *)moPubNetworkName {


### PR DESCRIPTION
- With current adapter source when Tapjoy token is not available  In those cases, we return "1" as the token. Hence update the API to not return "1"