### PR TITLE
Facebook Audience Network Adapter updates for banner - 5.4.0.1

### DIFF
--- a/FacebookAudienceNetwork/CHANGELOG.md
+++ b/FacebookAudienceNetwork/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Changelog
+* 5.4.0.1
+    * Fix banner size passing as part of ad format unification. This version is only compatible with the 5.8.0+ release of the MoPub SDK.
+
 * 5.4.0.0
     * This version of the adapters has been certified with Facebook Audience Network 5.4.0.
 

--- a/FacebookAudienceNetwork/FacebookAdapterConfiguration.m
+++ b/FacebookAudienceNetwork/FacebookAdapterConfiguration.m
@@ -14,7 +14,7 @@
 #import "MPConstants.h"
 #endif
 
-#define FACEBOOK_ADAPTER_VERSION             @"5.4.0.0"
+#define FACEBOOK_ADAPTER_VERSION             @"5.4.0.1"
 #define MOPUB_NETWORK_NAME                   @"facebook"
 
 static NSString * const kFacebookPlacementIDs = @"placement_ids";

--- a/FacebookAudienceNetwork/MoPub-FacebookAudienceNetwork-Podspecs/MoPub-FacebookAudienceNetwork-Adapters.podspec
+++ b/FacebookAudienceNetwork/MoPub-FacebookAudienceNetwork-Podspecs/MoPub-FacebookAudienceNetwork-Adapters.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
 s.name             = 'MoPub-FacebookAudienceNetwork-Adapters'
-s.version          = '5.4.0.0'
+s.version          = '5.4.0.1'
 s.summary          = 'Facebook Adapters for mediating through MoPub.'
 s.description      = <<-DESC
 Supported ad formats: Banners, Interstitial, Rewarded Video and Native.\n
@@ -19,11 +19,11 @@ s.source           = { :git => 'https://github.com/mopub/mopub-ios-mediation.git
 s.ios.deployment_target = '9.0'
 s.static_framework = true
 s.subspec 'MoPub' do |ms|
-  ms.dependency 'mopub-ios-sdk/Core', '~> 5.5'
+  ms.dependency 'mopub-ios-sdk/Core', '~> 5.6'
 end
 s.subspec 'Network' do |ns|
   ns.source_files = 'FacebookAudienceNetwork/*.{h,m}'
-  ns.dependency 'mopub-ios-sdk/Core', '~> 5.5'
+  ns.dependency 'mopub-ios-sdk/Core', '~> 5.6'
   ns.dependency 'FBAudienceNetwork', '5.4.0'
 end
 end


### PR DESCRIPTION
The changes in this PR are related to the email we sent earlier related to the subject line `[Facebook] Upcoming MoPub Banner and Medium Rectangle Banner changes.`

Please let us know if these changes look good to you. Thanks!