### PR TITLE
AppLovin - Remove extraneous `else` block in the banner adapter

### DIFF
--- a/AppLovin/AppLovinBannerCustomEvent.m
+++ b/AppLovin/AppLovinBannerCustomEvent.m
@@ -102,16 +102,6 @@ static NSMutableDictionary<NSString *, ALAdView *> *ALGlobalAdViews;
         
         MPLogAdEvent([MPLogEvent adLoadAttemptForAdapter:NSStringFromClass(self.class) dspCreativeId:nil dspName:nil], zoneIdentifier);
     }
-    else
-    {
-        NSString *failureReason = [NSString stringWithFormat: @"Adapter requested to display a banner with invalid size: %@.", NSStringFromCGSize(size)];
-        NSError *error = [NSError errorWithDomain: kALMoPubMediationErrorDomain
-                                             code: kALErrorCodeUnableToRenderAd
-                                         userInfo: @{NSLocalizedFailureReasonErrorKey : failureReason}];
-        
-        [self.delegate bannerCustomEvent: self didFailToLoadAdWithError: error];
-        MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:error], zoneIdentifier);
-    }
 }
 
 - (BOOL)enableAutomaticImpressionAndClickTracking

--- a/AppLovin/CHANGELOG.md
+++ b/AppLovin/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Changelog
    * 6.8.0.0
      * This version of the adapters has been certified with AppLovin SDK 6.8.0.
+
+    * 6.7.1.1
      * Fix banner size passing as part of ad format unification. This version is only compatible with the 5.8.0+ release of the MoPub SDK.
 
    * 6.7.1.0


### PR DESCRIPTION
@thomasmso, does it sound good to remove this `else` block that handles failures? Right now there are 2 `else`s.