### PR TITLE
Release Tapjoy adapters 12.3.1.3

### DIFF
--- a/Tapjoy/CHANGELOG.md
+++ b/Tapjoy/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Changelog
+  * 12.3.1.3
+    * Set video delegate correctly to receive `TJPlacementVideoDelegate` callbacks so that the user is rewarded after video completion.
+
   * 12.3.1.2
     * Remove duplicate `Tapjoy connect` calls in `TapjoyAdapterConfiguration`.
     

--- a/Tapjoy/MoPub-Tapjoy-PodSpecs/MoPub-TapJoy-Adapters.podspec
+++ b/Tapjoy/MoPub-Tapjoy-PodSpecs/MoPub-TapJoy-Adapters.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
 s.name             = 'MoPub-TapJoy-Adapters'
-s.version          = '12.3.1.2'
+s.version          = '12.3.1.3'
 s.summary          = 'TapJoy Adapters for mediating through MoPub.'
 s.description      = <<-DESC
 Supported ad formats: Interstitial, Rewarded Video.\n

--- a/Tapjoy/TapjoyAdapterConfiguration.m
+++ b/Tapjoy/TapjoyAdapterConfiguration.m
@@ -41,7 +41,7 @@ typedef NS_ENUM(NSInteger, TapjoyAdapterErrorCode) {
 #pragma mark - MPAdapterConfiguration
 
 - (NSString *)adapterVersion {
-    return @"12.3.1.2";
+    return @"12.3.1.3";
 }
 
 - (NSString *)biddingToken {

--- a/Tapjoy/TapjoyRewardedVideoCustomEvent.m
+++ b/Tapjoy/TapjoyRewardedVideoCustomEvent.m
@@ -109,7 +109,7 @@
                 [self.placement setAuctionData:auctionData];
             }
         }
-        
+
         MPLogAdEvent([MPLogEvent adLoadAttemptForAdapter:NSStringFromClass(self.class) dspCreativeId:nil dspName:nil], self.placementName);
         [self.placement requestContent];
     }

--- a/Tapjoy/TapjoyRewardedVideoCustomEvent.m
+++ b/Tapjoy/TapjoyRewardedVideoCustomEvent.m
@@ -98,6 +98,7 @@
     if (self.placementName != nil) {
         self.placement = [TJPlacement placementWithName:self.placementName mediationAgent:@"mopub" mediationId:nil delegate:self];
         self.placement.adapterVersion = MP_SDK_VERSION;
+        self.placement.videoDelegate = self;
         
         // Advanced bidding response
         if (adMarkup != nil) {
@@ -108,7 +109,7 @@
                 [self.placement setAuctionData:auctionData];
             }
         }
-
+        
         MPLogAdEvent([MPLogEvent adLoadAttemptForAdapter:NSStringFromClass(self.class) dspCreativeId:nil dspName:nil], self.placementName);
         [self.placement requestContent];
     }
@@ -199,7 +200,7 @@
 #pragma mark Tapjoy Video
 
 - (void)videoDidStart:(TJPlacement *)placement {
-    MPLogAdEvent([MPLogEvent adWillAppearForAdapter:NSStringFromClass(self.class)], self.placement);
+    MPLogAdEvent([MPLogEvent adWillAppearForAdapter:NSStringFromClass(self.class)], self.placementName);
 }
 
 - (void)videoDidComplete:(TJPlacement*)placement {
@@ -207,7 +208,7 @@
 }
 
 - (void)videoDidFail:(TJPlacement*)placement error:(NSString*)errorMsg {
-    MPLogAdEvent([MPLogEvent adShowFailedForAdapter:NSStringFromClass(self.class) error:errorMsg], self.placement);
+    MPLogAdEvent([MPLogEvent adShowFailedForAdapter:NSStringFromClass(self.class) error:[NSError errorWithCode:MOPUBErrorUnknown localizedDescription:errorMsg]], self.placementName);
 }
 
 - (void)tjcConnectSuccess:(NSNotification*)notifyObj {


### PR DESCRIPTION
This PR is to implement TJPlacementVideoDelegate properly so that`TJPlacementVideoDelegate` callbacks get called correctly and some logging correction in `TapjoyRewardedVideoCustomEvent.m`. 

How to test:

- Run MoPub sample app with latest Mopub SDK, Tapjoy SDK and Tapjoy Adapter from this branch.
- Request Tapjoy video placement.
- Put break points on `videoDidStart`, `videoDidComplete`callbacks.
- Show and play the video ads.
- Observe if `videoDidStart`, `videoDidComplete`callbacks get fired. 
