### PR TITLE
Unity Ads Adaptor Update 3.3

### DIFF
--- a/UnityAds/UnityAdsBannerCustomEvent.h
+++ b/UnityAds/UnityAdsBannerCustomEvent.h
@@ -8,6 +8,6 @@
     #import "MPBannerCustomEvent.h"
 #endif
 
-@interface UnityAdsBannerCustomEvent : MPBannerCustomEvent<UnityAdsBannerDelegate>
+@interface UnityAdsBannerCustomEvent : MPBannerCustomEvent<UADSBannerAdViewDelegate>
 
 @end

--- a/UnityAds/UnityAdsBannerCustomEvent.m
+++ b/UnityAds/UnityAdsBannerCustomEvent.m
@@ -15,6 +15,7 @@ static NSString *const kUnityAdsOptionZoneIdKey = @"zoneId";
 
 @interface UnityAdsBannerCustomEvent ()
 @property (nonatomic) NSString* placementId;
+@property (nonatomic) UADSBannerAdView* bannerView;
 @end
 
 @implementation UnityAdsBannerCustomEvent
@@ -27,7 +28,7 @@ static NSString *const kUnityAdsOptionZoneIdKey = @"zoneId";
 }
 
 -(void)dealloc {
-    [UnityAdsBanner destroy];
+
 }
 
 -(void)requestAdWithSize:(CGSize)size customEventInfo:(NSDictionary *)info {
@@ -46,7 +47,11 @@ static NSString *const kUnityAdsOptionZoneIdKey = @"zoneId";
         return;
     }
 
-    [[UnityRouter sharedRouter] requestBannerAdWithGameId:gameId placementId:self.placementId delegate:self];
+    [[UnityRouter sharedRouter] initializeWithGameId:gameId];
+    _bannerView = [[UADSBannerAdView alloc] initWithPlacementId:_placementId size:size];
+    [_bannerView setDelegate:self];
+    [_bannerView load];
+
     MPLogAdEvent([MPLogEvent adLoadAttemptForAdapter:NSStringFromClass(self.class) dspCreativeId:nil dspName:nil], [self getAdNetworkId]);
 }
 
@@ -62,35 +67,78 @@ static NSString *const kUnityAdsOptionZoneIdKey = @"zoneId";
     return [NSError errorWithDomain:NSStringFromClass([self class]) code:0 userInfo:userInfo];
 }
 
--(void)unityAdsBannerDidLoad:(NSString *)placementId view:(UIView *)view {
-    MPLogAdEvent([MPLogEvent adLoadSuccessForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
-    MPLogAdEvent([MPLogEvent adShowAttemptForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
-    MPLogAdEvent([MPLogEvent adShowSuccessForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
-
-    [self.delegate bannerCustomEvent:self didLoadAd:view];
-}
-
--(void)unityAdsBannerDidUnload:(NSString *)placementId {
-    MPLogInfo(@"Unity Banner did unload for placement %@", placementId);
-}
--(void)unityAdsBannerDidShow:(NSString *)placementId {
-    MPLogInfo(@"Unity Banner did show for placement %@", placementId);
-}
--(void)unityAdsBannerDidHide:(NSString *)placementId {
-    MPLogInfo(@"Unity Banner did hide for placement %@", placementId);
-}
--(void)unityAdsBannerDidClick:(NSString *)placementId {
-    MPLogAdEvent([MPLogEvent adTappedForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
-    [self.delegate bannerCustomEventWillLeaveApplication:self];
-}
--(void)unityAdsBannerDidError:(NSString *)message {
-    NSError *error = [self createErrorWith:@"Unity Ads failed to load an ad"
+-(void)unityAdsBannerDidNoFill:(UADSBannerAdView *)bannerAdView {
+    NSError *error = [self createErrorWith:[@"Unity Ads returned no fill for banner placement"
+                                            stringByAppendingString:bannerAdView.placementId]
                                  andReason:@""
                              andSuggestion:@""];
 
     MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:error], [self getAdNetworkId]);
     [self.delegate bannerCustomEvent:self didFailToLoadAdWithError:nil];
 }
+
+-(void)unityAdsBannerDidLoad:(UADSBannerAdView *)bannerAdView {
+    MPLogAdEvent([MPLogEvent adLoadSuccessForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
+    MPLogAdEvent([MPLogEvent adShowAttemptForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
+    MPLogAdEvent([MPLogEvent adShowSuccessForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
+
+    [self.delegate bannerCustomEvent:self didLoadAd:bannerAdView];
+}
+
+/**
+ Called when the banner is unloaded and references to it should be discarded.
+ The view provided in unityAdsBannerDidLoad will be removed from the view hierarchy before
+ this method is called.
+ *
+ * @param bannerAdView View that unloaded.
+ */
+-(void)unityAdsBannerDidUnload:(UADSBannerAdView *)bannerAdView {
+     MPLogInfo(@"Unity Banner did unload for placement %@", bannerAdView.placementId);
+}
+
+/**
+ * Called when the banner is shown.
+ *
+ * @param bannerAdView View that was shown.
+ */
+-(void)unityAdsBannerDidShow:(UADSBannerAdView *)bannerAdView {
+    MPLogInfo(@"Unity Banner did show for placement %@", bannerAdView.placementId);
+}
+
+/**
+ * Called when the banner is hidden.
+ *
+ * @param bannerAdView View that was hidden
+ */
+-(void)unityAdsBannerDidHide:(UADSBannerAdView *)bannerAdView {
+    MPLogInfo(@"Unity Banner did hide for placement %@", bannerAdView.placementId);
+}
+
+/**
+ * Called when the user clicks the banner.
+ *
+ * @param bannerAdView View that the click occurred on.
+ */
+-(void)unityAdsBannerDidClick:(UADSBannerAdView *)bannerAdView {
+    MPLogAdEvent([MPLogEvent adTappedForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
+    [self.delegate bannerCustomEventWillLeaveApplication:self];
+}
+
+/**
+ *  Called when `UnityAdsBanner` encounters an error.
+ *
+ *  @param bannerAdView View that encountered an error.
+ *  @param message A human readable string indicating the type of error encountered.
+ */
+-(void)unityAdsBannerDidError:(UADSBannerAdView *)bannerAdView message:(NSString *)message {
+    NSError *error = [self createErrorWith:message
+                                 andReason:@""
+                             andSuggestion:@""];
+
+    MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:error], [self getAdNetworkId]);
+    [self.delegate bannerCustomEvent:self didFailToLoadAdWithError:nil];
+}
+
 
 - (NSString *) getAdNetworkId {
     return (self.placementId != nil) ? self.placementId : @"";

--- a/UnityAds/UnityRouter.h
+++ b/UnityAds/UnityRouter.h
@@ -13,7 +13,7 @@
 @protocol UnityRouterDelegate;
 @class UnityAdsInstanceMediationSettings;
 
-@interface UnityRouter : NSObject <UnityAdsExtendedDelegate, UnityAdsBannerDelegate>
+@interface UnityRouter : NSObject <UnityAdsExtendedDelegate>
 
 @property NSString* currentPlacementId;
 
@@ -21,7 +21,6 @@
 
 - (void)initializeWithGameId:(NSString *)gameId;
 - (void)requestVideoAdWithGameId:(NSString *)gameId placementId:(NSString *)placementId delegate:(id<UnityRouterDelegate>)delegate;
-- (void)requestBannerAdWithGameId:(NSString *)gameId placementId:(NSString *)placementId delegate:(id<UnityAdsBannerDelegate>)delegate;
 - (BOOL)isAdAvailableForPlacementId:(NSString *)placementId;
 - (void)presentVideoAdFromViewController:(UIViewController *)viewController customerId:(NSString *)customerId placementId:(NSString *)placementId settings:(UnityAdsInstanceMediationSettings *)settings delegate:(id<UnityRouterDelegate>)delegate;
 - (void)clearDelegate:(id<UnityRouterDelegate>)delegate;

--- a/UnityAds/UnityRouter.m
+++ b/UnityAds/UnityRouter.m
@@ -126,18 +126,6 @@
     }
 }
 
--(void)requestBannerAdWithGameId:(NSString *)gameId placementId:(NSString *)placementId delegate:(id <UnityAdsBannerDelegate>)delegate {
-    [self initializeWithGameId:gameId];
-    self.bannerDelegate = delegate;
-
-    if ([UnityAds isReady:placementId]) {
-        [UnityAdsBanner loadBanner:placementId];
-    } else {
-        self.bannerLoadRequested = YES;
-        self.bannerPlacementId = placementId;
-    }
-}
-
 - (BOOL)isAdAvailableForPlacementId:(NSString *)placementId
 {
     return [UnityAds isReady:placementId];
@@ -238,28 +226,6 @@
         NSError *error = [NSError errorWithDomain:MoPubRewardedVideoAdsSDKDomain code:MPRewardedVideoAdErrorUnknown userInfo:nil];
         [delegate unityAdsDidFailWithError:error];
     }
-}
-
-#pragma mark - UnityAdsBannerDelegate
-
--(void)unityAdsBannerDidLoad:(NSString *)placementId view:(UIView *)view {
-    [self.bannerDelegate unityAdsBannerDidLoad:placementId view:view];
-}
-
--(void)unityAdsBannerDidUnload:(NSString *)placementId {
-    [self.bannerDelegate unityAdsBannerDidUnload:placementId];
-}
--(void)unityAdsBannerDidShow:(NSString *)placementId {
-    [self.bannerDelegate unityAdsBannerDidShow:placementId];
-}
--(void)unityAdsBannerDidHide:(NSString *)placementId {
-    [self.bannerDelegate unityAdsBannerDidHide:placementId];
-}
--(void)unityAdsBannerDidClick:(NSString *)placementId {
-    [self.bannerDelegate unityAdsBannerDidClick:placementId];
-}
--(void)unityAdsBannerDidError:(NSString *)message {
-    [self.bannerDelegate unityAdsBannerDidError:message];
 }
 
 @end


### PR DESCRIPTION
**Change log**

Multiple Banners
- Now supports multiple banners from one placement

Updated Banner API
- Old banner API deprecated
- New API uses ad objects that set the BannerCustomEvent a delegate
- Banner can now be requested before Initialization is complete
- Added no-fill callback to differentiate between SDK errors and no-fill responses