### PR TITLE
Unity Ads Adaptor Update 3.3

### DIFF
--- a/UnityAds/UnityAdsBannerCustomEvent.h
+++ b/UnityAds/UnityAdsBannerCustomEvent.h
@@ -8,6 +8,6 @@
     #import "MPBannerCustomEvent.h"
 #endif
 
-@interface UnityAdsBannerCustomEvent : MPBannerCustomEvent<UnityAdsBannerDelegate>
+@interface UnityAdsBannerCustomEvent : MPBannerCustomEvent<UADSBannerAdViewDelegate>
 
 @end

--- a/UnityAds/UnityRouter.h
+++ b/UnityAds/UnityRouter.h
@@ -8,12 +8,11 @@
 #import <Foundation/Foundation.h>
 #import <UnityAds/UnityAds.h>
 #import <UnityAds/UnityAdsExtended.h>
-#import <UnityAds/UADSBanner.h>
 
 @protocol UnityRouterDelegate;
 @class UnityAdsInstanceMediationSettings;
 
-@interface UnityRouter : NSObject <UnityAdsExtendedDelegate, UnityAdsBannerDelegate>
+@interface UnityRouter : NSObject <UnityAdsExtendedDelegate>
 
 @property NSString* currentPlacementId;
 
@@ -21,7 +20,6 @@
 
 - (void)initializeWithGameId:(NSString *)gameId;
 - (void)requestVideoAdWithGameId:(NSString *)gameId placementId:(NSString *)placementId delegate:(id<UnityRouterDelegate>)delegate;
-- (void)requestBannerAdWithGameId:(NSString *)gameId placementId:(NSString *)placementId delegate:(id<UnityAdsBannerDelegate>)delegate;
 - (BOOL)isAdAvailableForPlacementId:(NSString *)placementId;
 - (void)presentVideoAdFromViewController:(UIViewController *)viewController customerId:(NSString *)customerId placementId:(NSString *)placementId settings:(UnityAdsInstanceMediationSettings *)settings delegate:(id<UnityRouterDelegate>)delegate;
 - (void)clearDelegate:(id<UnityRouterDelegate>)delegate;

--- a/UnityAds/UnityRouter.m
+++ b/UnityAds/UnityRouter.m
@@ -25,10 +25,6 @@
 @property (nonatomic, weak) id<UnityRouterDelegate> delegate;
 
 @property NSMutableDictionary* delegateMap;
-@property id<UnityAdsBannerDelegate> bannerDelegate;
-
-@property BOOL bannerLoadRequested;
-@property NSString* bannerPlacementId;
 
 @property (nonatomic, assign) int impressionOrdinal;
 @property (nonatomic, assign) int missedImpressionOrdinal;
@@ -64,7 +60,6 @@
         [mediationMetaData set:@"adapter_version"  value:ADAPTER_VERSION];
         [mediationMetaData commit];
         
-        [UnityAdsBanner setDelegate:self];
         [UnityAds initialize:gameId delegate:self testMode:false enablePerPlacementLoad:true];
     });
     [self setIfUnityAdsCollectsPersonalInfo];
@@ -126,18 +121,6 @@
     }
 }
 
--(void)requestBannerAdWithGameId:(NSString *)gameId placementId:(NSString *)placementId delegate:(id <UnityAdsBannerDelegate>)delegate {
-    [self initializeWithGameId:gameId];
-    self.bannerDelegate = delegate;
-
-    if ([UnityAds isReady:placementId]) {
-        [UnityAdsBanner loadBanner:placementId];
-    } else {
-        self.bannerLoadRequested = YES;
-        self.bannerPlacementId = placementId;
-    }
-}
-
 - (BOOL)isAdAvailableForPlacementId:(NSString *)placementId
 {
     return [UnityAds isReady:placementId];
@@ -177,20 +160,11 @@
     }
 }
 
--(void)clearBannerDelegate {
-    self.bannerDelegate = nil;
-    self.bannerPlacementId = nil;
-    self.bannerLoadRequested = NO;
-}
-
 #pragma mark - UnityAdsExtendedDelegate
 
 - (void)unityAdsReady:(NSString *)placementId
 {
-    if ([placementId isEqualToString:self.bannerPlacementId] && self.bannerLoadRequested) {
-        self.bannerLoadRequested = NO;
-        [UnityAdsBanner loadBanner:self.bannerPlacementId];
-    } else if (!self.isAdPlaying) {
+    if (!self.isAdPlaying) {
         id delegate = [self getDelegate:placementId];
         if (delegate != nil) {
             [delegate unityAdsReady:placementId];
@@ -238,28 +212,6 @@
         NSError *error = [NSError errorWithDomain:MoPubRewardedVideoAdsSDKDomain code:MPRewardedVideoAdErrorUnknown userInfo:nil];
         [delegate unityAdsDidFailWithError:error];
     }
-}
-
-#pragma mark - UnityAdsBannerDelegate
-
--(void)unityAdsBannerDidLoad:(NSString *)placementId view:(UIView *)view {
-    [self.bannerDelegate unityAdsBannerDidLoad:placementId view:view];
-}
-
--(void)unityAdsBannerDidUnload:(NSString *)placementId {
-    [self.bannerDelegate unityAdsBannerDidUnload:placementId];
-}
--(void)unityAdsBannerDidShow:(NSString *)placementId {
-    [self.bannerDelegate unityAdsBannerDidShow:placementId];
-}
--(void)unityAdsBannerDidHide:(NSString *)placementId {
-    [self.bannerDelegate unityAdsBannerDidHide:placementId];
-}
--(void)unityAdsBannerDidClick:(NSString *)placementId {
-    [self.bannerDelegate unityAdsBannerDidClick:placementId];
-}
--(void)unityAdsBannerDidError:(NSString *)message {
-    [self.bannerDelegate unityAdsBannerDidError:message];
 }
 
 @end


### PR DESCRIPTION
**Change log**

Multiple Banners
- Now supports multiple banners from one placement
- Updated Banner API

Old banner API deprecated
- New API uses ad objects that interact exclusively with BannerCustomEvent
- Banner can now be requested before Initialization is complete
- Added no-fill callback to differentiate between SDK errors and no-fill responses