### PR TITLE
Update Banner with Unity 3.3 release

### DIFF
--- a/UnityAds/UnityAdsBannerCustomEvent.h
+++ b/UnityAds/UnityAdsBannerCustomEvent.h
@@ -1,4 +1,4 @@
-#import <UnityAds/UADSBanner.h>
+#import <UnityAds/UADSBannerAdViewDelegate.h>
 
 #if __has_include(<MoPub/MoPub.h>)
     #import <MoPub/MoPub.h>
@@ -8,6 +8,5 @@
     #import "MPBannerCustomEvent.h"
 #endif
 
-@interface UnityAdsBannerCustomEvent : MPBannerCustomEvent<UnityAdsBannerDelegate>
-
+@interface UnityAdsBannerCustomEvent : MPBannerCustomEvent <UADSBannerAdViewDelegate>
 @end

--- a/UnityAds/UnityAdsBannerCustomEvent.h
+++ b/UnityAds/UnityAdsBannerCustomEvent.h
@@ -1,4 +1,4 @@
-#import <UnityAds/UADSBannerAdViewDelegate.h>
+#import <UnityAds/UADSBannerViewDelegate.h>
 
 #if __has_include(<MoPub/MoPub.h>)
     #import <MoPub/MoPub.h>
@@ -8,5 +8,5 @@
     #import "MPBannerCustomEvent.h"
 #endif
 
-@interface UnityAdsBannerCustomEvent : MPBannerCustomEvent <UADSBannerAdViewDelegate>
+@interface UnityAdsBannerCustomEvent : MPBannerCustomEvent <UADSBannerViewDelegate>
 @end

--- a/UnityAds/UnityAdsBannerCustomEvent.m
+++ b/UnityAds/UnityAdsBannerCustomEvent.m
@@ -72,37 +72,28 @@ static NSString *const kUnityAdsOptionZoneIdKey = @"zoneId";
 
 #pragma mark - UADSBannerViewDelegate
 
--(void)unityAdsBannerDidLoad:(UADSBannerView *)bannerAdView {
+- (void)bannerViewDidLoad:(UADSBannerView *)bannerView {
     MPLogAdEvent([MPLogEvent adLoadSuccessForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
     MPLogAdEvent([MPLogEvent adShowAttemptForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
     MPLogAdEvent([MPLogEvent adShowSuccessForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
-    [self.delegate bannerCustomEvent:self didLoadAd:bannerAdView];
+    [self.delegate bannerCustomEvent:self didLoadAd:bannerView];
 }
 
--(void)unityAdsBannerDidUnload:(UADSBannerView *)bannerAdView {
-    MPLogInfo(@"Unity Banner did unload for %@", bannerAdView.viewId);
-}
-
--(void)unityAdsBannerDidShow:(UADSBannerView *)bannerAdView {
-    MPLogInfo(@"Unity Banner did show for %@", bannerAdView.viewId);
-}
-
--(void)unityAdsBannerDidHide:(UADSBannerView *)bannerAdView {
-    MPLogInfo(@"Unity Banner did hide for %@", bannerAdView.viewId);
-}
-
--(void)unityAdsBannerDidClick:(UADSBannerView *)bannerAdView {
+- (void)bannerViewDidClick:(UADSBannerView *)bannerView {
     MPLogAdEvent([MPLogEvent adTappedForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
+    [self.delegate trackClick];
+}
+
+- (void)bannerViewDidLeaveApplication:(UADSBannerView *)bannerView {
     [self.delegate bannerCustomEventWillLeaveApplication:self];
 }
 
--(void)unityAdsBannerDidError:(UADSBannerView *)bannerAdView error:(UADSBannerError *)error  {
-    if (error == UADSBannerErrorCodeNoFillError) {
-        NSError *error = [self createErrorWith:@"Unity Ads Banner returned no fill" andReason:@"" andSuggestion:@""];
-    } else {
-        NSError *error = [self createErrorWith:@"Unity Ads failed to load an ad" andReason:@"" andSuggestion:@""];
+- (void)bannerViewDidError:(UADSBannerView *)bannerView error:(UADSBannerError *)error{
+    if ([error code] == UADSBannerErrorCodeNoFillError) {
+        NSError *mopubAdaptorErrorMessage = [self createErrorWith:@"Unity Ads Banner returned no fill" andReason:@"" andSuggestion:@""];
+        MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:mopubAdaptorErrorMessage], [self getAdNetworkId]);
     }
-    MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:error], [self getAdNetworkId]);
+
     [self.delegate bannerCustomEvent:self didFailToLoadAdWithError:nil];
 }
 

--- a/UnityAds/UnityAdsBannerCustomEvent.m
+++ b/UnityAds/UnityAdsBannerCustomEvent.m
@@ -15,7 +15,7 @@ static NSString *const kUnityAdsOptionZoneIdKey = @"zoneId";
 
 @interface UnityAdsBannerCustomEvent ()
 @property (nonatomic, strong) NSString* placementId;
-@property (nonatomic, strong) UADSBannerAdView* bannerAdView;
+@property (nonatomic, strong) UADSBannerView* bannerAdView;
 @end
 
 @implementation UnityAdsBannerCustomEvent
@@ -51,7 +51,7 @@ static NSString *const kUnityAdsOptionZoneIdKey = @"zoneId";
     }
     [[UnityRouter sharedRouter] initializeWithGameId:gameId];
     
-    self.bannerAdView = [[UADSBannerAdView alloc] initWithPlacementId:self.placementId size:size];
+    self.bannerAdView = [[UADSBannerView alloc] initWithPlacementId:self.placementId size:size];
     self.bannerAdView.delegate = self;
     [self.bannerAdView load];
 
@@ -70,41 +70,38 @@ static NSString *const kUnityAdsOptionZoneIdKey = @"zoneId";
     return [NSError errorWithDomain:NSStringFromClass([self class]) code:0 userInfo:userInfo];
 }
 
-#pragma mark - UADSBannerAdViewDelegate
+#pragma mark - UADSBannerViewDelegate
 
--(void)unityAdsBannerDidLoad:(UADSBannerAdView *)bannerAdView {
+-(void)unityAdsBannerDidLoad:(UADSBannerView *)bannerAdView {
     MPLogAdEvent([MPLogEvent adLoadSuccessForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
     MPLogAdEvent([MPLogEvent adShowAttemptForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
     MPLogAdEvent([MPLogEvent adShowSuccessForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
     [self.delegate bannerCustomEvent:self didLoadAd:bannerAdView];
 }
 
--(void)unityAdsBannerDidNoFill:(UADSBannerAdView *)bannerAdView {
-    NSLog(@"BannerAdView(%@) did not fill!", bannerAdView.viewId);
-}
-
--(void)unityAdsBannerDidUnload:(UADSBannerAdView *)bannerAdView {
+-(void)unityAdsBannerDidUnload:(UADSBannerView *)bannerAdView {
     MPLogInfo(@"Unity Banner did unload for %@", bannerAdView.viewId);
 }
 
--(void)unityAdsBannerDidShow:(UADSBannerAdView *)bannerAdView {
+-(void)unityAdsBannerDidShow:(UADSBannerView *)bannerAdView {
     MPLogInfo(@"Unity Banner did show for %@", bannerAdView.viewId);
 }
 
--(void)unityAdsBannerDidHide:(UADSBannerAdView *)bannerAdView {
+-(void)unityAdsBannerDidHide:(UADSBannerView *)bannerAdView {
     MPLogInfo(@"Unity Banner did hide for %@", bannerAdView.viewId);
 }
 
--(void)unityAdsBannerDidClick:(UADSBannerAdView *)bannerAdView {
+-(void)unityAdsBannerDidClick:(UADSBannerView *)bannerAdView {
     MPLogAdEvent([MPLogEvent adTappedForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
     [self.delegate bannerCustomEventWillLeaveApplication:self];
 }
 
--(void)unityAdsBannerDidError:(UADSBannerAdView *)bannerAdView message:(NSString *)message  {
-    NSError *error = [self createErrorWith:@"Unity Ads failed to load an ad"
-                                 andReason:@""
-                             andSuggestion:@""];
-
+-(void)unityAdsBannerDidError:(UADSBannerView *)bannerAdView error:(UADSBannerError *)error  {
+    if (error == UADSBannerErrorCodeNoFillError) {
+        NSError *error = [self createErrorWith:@"Unity Ads Banner returned no fill" andReason:@"" andSuggestion:@""];
+    } else {
+        NSError *error = [self createErrorWith:@"Unity Ads failed to load an ad" andReason:@"" andSuggestion:@""];
+    }
     MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:error], [self getAdNetworkId]);
     [self.delegate bannerCustomEvent:self didFailToLoadAdWithError:nil];
 }

--- a/UnityAds/UnityRouter.h
+++ b/UnityAds/UnityRouter.h
@@ -8,12 +8,11 @@
 #import <Foundation/Foundation.h>
 #import <UnityAds/UnityAds.h>
 #import <UnityAds/UnityAdsExtended.h>
-#import <UnityAds/UADSBanner.h>
 
 @protocol UnityRouterDelegate;
 @class UnityAdsInstanceMediationSettings;
 
-@interface UnityRouter : NSObject <UnityAdsExtendedDelegate, UnityAdsBannerDelegate>
+@interface UnityRouter : NSObject <UnityAdsExtendedDelegate>
 
 @property NSString* currentPlacementId;
 
@@ -21,7 +20,6 @@
 
 - (void)initializeWithGameId:(NSString *)gameId;
 - (void)requestVideoAdWithGameId:(NSString *)gameId placementId:(NSString *)placementId delegate:(id<UnityRouterDelegate>)delegate;
-- (void)requestBannerAdWithGameId:(NSString *)gameId placementId:(NSString *)placementId delegate:(id<UnityAdsBannerDelegate>)delegate;
 - (BOOL)isAdAvailableForPlacementId:(NSString *)placementId;
 - (void)presentVideoAdFromViewController:(UIViewController *)viewController customerId:(NSString *)customerId placementId:(NSString *)placementId settings:(UnityAdsInstanceMediationSettings *)settings delegate:(id<UnityRouterDelegate>)delegate;
 - (void)clearDelegate:(id<UnityRouterDelegate>)delegate;

--- a/UnityAds/UnityRouter.m
+++ b/UnityAds/UnityRouter.m
@@ -25,7 +25,6 @@
 @property (nonatomic, weak) id<UnityRouterDelegate> delegate;
 
 @property NSMutableDictionary* delegateMap;
-@property id<UnityAdsBannerDelegate> bannerDelegate;
 
 @property BOOL bannerLoadRequested;
 @property NSString* bannerPlacementId;
@@ -64,7 +63,6 @@
         [mediationMetaData set:@"adapter_version"  value:ADAPTER_VERSION];
         [mediationMetaData commit];
         
-        [UnityAdsBanner setDelegate:self];
         [UnityAds initialize:gameId delegate:self testMode:false enablePerPlacementLoad:true];
     });
     [self setIfUnityAdsCollectsPersonalInfo];
@@ -126,18 +124,6 @@
     }
 }
 
--(void)requestBannerAdWithGameId:(NSString *)gameId placementId:(NSString *)placementId delegate:(id <UnityAdsBannerDelegate>)delegate {
-    [self initializeWithGameId:gameId];
-    self.bannerDelegate = delegate;
-
-    if ([UnityAds isReady:placementId]) {
-        [UnityAdsBanner loadBanner:placementId];
-    } else {
-        self.bannerLoadRequested = YES;
-        self.bannerPlacementId = placementId;
-    }
-}
-
 - (BOOL)isAdAvailableForPlacementId:(NSString *)placementId
 {
     return [UnityAds isReady:placementId];
@@ -177,19 +163,12 @@
     }
 }
 
--(void)clearBannerDelegate {
-    self.bannerDelegate = nil;
-    self.bannerPlacementId = nil;
-    self.bannerLoadRequested = NO;
-}
-
 #pragma mark - UnityAdsExtendedDelegate
 
 - (void)unityAdsReady:(NSString *)placementId
 {
     if ([placementId isEqualToString:self.bannerPlacementId] && self.bannerLoadRequested) {
         self.bannerLoadRequested = NO;
-        [UnityAdsBanner loadBanner:self.bannerPlacementId];
     } else if (!self.isAdPlaying) {
         id delegate = [self getDelegate:placementId];
         if (delegate != nil) {
@@ -238,28 +217,6 @@
         NSError *error = [NSError errorWithDomain:MoPubRewardedVideoAdsSDKDomain code:MPRewardedVideoAdErrorUnknown userInfo:nil];
         [delegate unityAdsDidFailWithError:error];
     }
-}
-
-#pragma mark - UnityAdsBannerDelegate
-
--(void)unityAdsBannerDidLoad:(NSString *)placementId view:(UIView *)view {
-    [self.bannerDelegate unityAdsBannerDidLoad:placementId view:view];
-}
-
--(void)unityAdsBannerDidUnload:(NSString *)placementId {
-    [self.bannerDelegate unityAdsBannerDidUnload:placementId];
-}
--(void)unityAdsBannerDidShow:(NSString *)placementId {
-    [self.bannerDelegate unityAdsBannerDidShow:placementId];
-}
--(void)unityAdsBannerDidHide:(NSString *)placementId {
-    [self.bannerDelegate unityAdsBannerDidHide:placementId];
-}
--(void)unityAdsBannerDidClick:(NSString *)placementId {
-    [self.bannerDelegate unityAdsBannerDidClick:placementId];
-}
--(void)unityAdsBannerDidError:(NSString *)message {
-    [self.bannerDelegate unityAdsBannerDidError:message];
 }
 
 @end


### PR DESCRIPTION
Change log

Multiple Banners

Now supports multiple banners from one placement
Updated Banner API
Old banner API deprecated

New API uses ad objects that interact exclusively with BannerCustomEvent
Banner can now be requested before Initialization is complete
Added no-fill callback to differentiate between SDK errors and no-fill responses
