### PR TITLE
Bugfix: No such thing as MPBLogLevel or MPBLogLevelDebug.

### DIFF
--- a/AppLovin/AppLovinAdapterConfiguration.m
+++ b/AppLovin/AppLovinAdapterConfiguration.m
@@ -81,8 +81,8 @@ typedef NS_ENUM(NSInteger, AppLovinAdapterErrorCode)
     
     if ( completionBlock ) completionBlock( error );
     
-    MPBLogLevel logLevel = [MPLogging consoleLogLevel];
-    BOOL verboseLoggingEnabled = (logLevel == MPBLogLevelDebug);
+    MPLogLevel logLevel = [MPLogging consoleLogLevel];
+    BOOL verboseLoggingEnabled = (logLevel == MPLogLevelDebug);
 
     [[ALSdk sharedWithKey: AppLovinAdapterConfiguration.sdkKey].settings setIsVerboseLogging: verboseLoggingEnabled];
 }


### PR DESCRIPTION
The AppLovin adapter seems to have a typo which will not compile: MPLogLevel and MPLogLevelDebug are referenced as MPBLogLevel and MPBLogLevelDebug, respectively.