### PR TITLE
AppLovin - Fail fast if SDK Key is not available - 6.9.4.1

### DIFF
--- a/AppLovin/AppLovinAdapterConfiguration.m
+++ b/AppLovin/AppLovinAdapterConfiguration.m
@@ -20,7 +20,7 @@ static ALSdk *__nullable AppLovinAdapterConfigurationSDK;
 
 static NSString *const kAppLovinSDKInfoPlistKey = @"AppLovinSdkKey";
 static NSString *const kAdapterErrorDomain = @"com.mopub.mopub-ios-sdk.mopub-applovin-adapters";
-static NSString *const kAdapterVersion = @"6.9.4.0";
+static NSString *const kAdapterVersion = @"6.9.4.1";
 
 static NSString *gSdkKey = nil;
 

--- a/AppLovin/AppLovinBannerCustomEvent.m
+++ b/AppLovin/AppLovinBannerCustomEvent.m
@@ -67,6 +67,20 @@ static NSMutableDictionary<NSString *, ALAdView *> *ALGlobalAdViews;
     }
     
     self.sdk = [self SDKFromCustomEventInfo: info];
+    
+    if (self.sdk == nil) {
+        NSString *failureReason = @"ALSdk instance is nil likely because no AppLovin SDK key is available. Failing ad request";
+        
+        NSError *error = [NSError errorWithDomain: kALMoPubMediationErrorDomain
+                                             code: kALErrorCodeSdkDisabled
+                                         userInfo: @{NSLocalizedFailureReasonErrorKey: failureReason}];
+        MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:error], @"");
+        
+        [self.delegate bannerCustomEvent:self didFailToLoadAdWithError: error];
+
+        return;
+    }
+
     self.sdk.mediationProvider = ALMediationProviderMoPub;
     [self.sdk setPluginVersion: AppLovinAdapterConfiguration.pluginVersion];
     

--- a/AppLovin/AppLovinInterstitialCustomEvent.m
+++ b/AppLovin/AppLovinInterstitialCustomEvent.m
@@ -68,6 +68,20 @@ static NSObject *ALGlobalInterstitialAdsLock;
     }
     
     self.sdk = [self SDKFromCustomEventInfo: info];
+    
+    if (self.sdk == nil) {
+        NSString *failureReason = @"ALSdk instance is nil likely because no AppLovin SDK key is available. Failing ad request";
+        
+        NSError *error = [NSError errorWithDomain: kALMoPubMediationErrorDomain
+                                             code: kALErrorCodeSdkDisabled
+                                         userInfo: @{NSLocalizedFailureReasonErrorKey: failureReason}];
+        MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:error], @"");
+        
+        [self.delegate interstitialCustomEvent:self didFailToLoadAdWithError: error];
+
+        return;
+    }
+
     self.sdk.mediationProvider = ALMediationProviderMoPub;
     [self.sdk setPluginVersion: AppLovinAdapterConfiguration.pluginVersion];
     

--- a/AppLovin/AppLovinRewardedVideoCustomEvent.m
+++ b/AppLovin/AppLovinRewardedVideoCustomEvent.m
@@ -69,6 +69,20 @@ static NSMutableDictionary<NSString *, ALIncentivizedInterstitialAd *> *ALGlobal
     }
     
     self.sdk = [self SDKFromCustomEventInfo: info];
+    
+    if (self.sdk == nil) {
+        NSString *failureReason = @"ALSdk instance is nil likely because no AppLovin SDK key is available. Failing ad request";
+        
+        NSError *error = [NSError errorWithDomain: kALMoPubMediationErrorDomain
+                                             code: kALErrorCodeSdkDisabled
+                                         userInfo: @{NSLocalizedFailureReasonErrorKey: failureReason}];
+        MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:error], @"");
+        
+        [self.delegate rewardedVideoDidFailToPlayForCustomEvent:self error: error];
+
+        return;
+    }
+
     self.sdk.mediationProvider = ALMediationProviderMoPub;
     [self.sdk setPluginVersion: AppLovinAdapterConfiguration.pluginVersion];
     

--- a/AppLovin/CHANGELOG.md
+++ b/AppLovin/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Changelog
+   * 6.9.4.1
+     * Fail fast when the AppLovin SDK Key is not inputted.
+
    * 6.9.4.0
      * This version of the adapters has been certified with AppLovin SDK 6.9.4.
 


### PR DESCRIPTION
Hey @thomasmso, could you help take a look at the proposed change here? We would like to fail fast and bail out if the SDK Key is not available (either from the Info.plist or programmatically passed in through MoPub's initialization). Otherwise, execution will get stuck as we don't get any callback or signal from AppLovin for the absence of the SDK Key. Thanks!