### PR TITLE
Remove dependency on FBAdIconView since it is deprecated

### DIFF
--- a/FacebookAudienceNetwork/FacebookNativeAdAdapter.m
+++ b/FacebookAudienceNetwork/FacebookNativeAdAdapter.m
@@ -17,7 +17,7 @@
 
 @property (nonatomic, readonly) FBAdOptionsView *adOptionsView;
 @property (nonatomic, readonly) FBMediaView *mediaView;
-@property (nonatomic, readonly) FBAdIconView *iconView;
+@property (nonatomic, readonly) FBMediaView *iconView;
 
 @end
 
@@ -31,7 +31,7 @@
         _fbNativeAd = fbNativeAd;
         _fbNativeAd.delegate = self;
         _mediaView = [[FBMediaView alloc] init];
-        _iconView = [[FBAdIconView alloc] init];
+        _iconView = [[FBMediaView alloc] init];
 
         NSMutableDictionary *properties;
         if (adProps) {


### PR DESCRIPTION
Use `FBMediaView` instead