### PR TITLE
No need to downcast to int to switch on this enum.

### DIFF
--- a/Chartboost/ChartboostAdapterConfiguration.m
+++ b/Chartboost/ChartboostAdapterConfiguration.m
@@ -95,9 +95,7 @@ typedef NS_ENUM(NSInteger, ChartboostAdapterErrorCode) {
 
 + (CBLoggingLevel)getChartboostLogLevel:(MPBLogLevel)logLevel
 {
-    int logLevelVal = logLevel;
-    
-    switch (logLevelVal) {
+    switch (logLevel) {
         case MPBLogLevelDebug:
             return CBLoggingLevelVerbose;
         case MPBLogLevelInfo:

--- a/UnityAds/UnityAdsAdapterConfiguration.m
+++ b/UnityAds/UnityAdsAdapterConfiguration.m
@@ -77,7 +77,7 @@ typedef NS_ENUM(NSInteger, UnityAdsAdapterErrorCode) {
         complete(nil);
     }
     
-    MPBLogLevel * logLevel = [[MoPub sharedInstance] logLevel];
+    MPBLogLevel logLevel = [[MoPub sharedInstance] logLevel];
     BOOL debugModeEnabled = logLevel == MPBLogLevelDebug;
 
     [UnityAds setDebugMode:debugModeEnabled];


### PR DESCRIPTION
Downcasting to an int produces loss of precision warning on 64 bit builds.