### PR TITLE
No need to downcast to int to switch on this enum.

### DIFF
--- a/Chartboost/CHANGELOG.md
+++ b/Chartboost/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Changelog
+  * 8.0.1.3
+      * Stop downcasting log level to `int`.
+
   * 8.0.1.2
       * Convert banner width and height to integers before passing them to Chartboost.
 

--- a/Chartboost/ChartboostAdapterConfiguration.m
+++ b/Chartboost/ChartboostAdapterConfiguration.m
@@ -7,7 +7,7 @@
 #import "MPLogging.h"
 #endif
 
-#define CHARTBOOST_ADAPTER_VERSION             @"8.0.1.2"
+#define CHARTBOOST_ADAPTER_VERSION             @"8.0.1.3"
 #define MOPUB_NETWORK_NAME                     @"chartboost"
 
 // Constants

--- a/Chartboost/ChartboostAdapterConfiguration.m
+++ b/Chartboost/ChartboostAdapterConfiguration.m
@@ -95,9 +95,7 @@ typedef NS_ENUM(NSInteger, ChartboostAdapterErrorCode) {
 
 + (CBLoggingLevel)getChartboostLogLevel:(MPBLogLevel)logLevel
 {
-    int logLevelVal = logLevel;
-    
-    switch (logLevelVal) {
+    switch (logLevel) {
         case MPBLogLevelDebug:
             return CBLoggingLevelVerbose;
         case MPBLogLevelInfo:


### PR DESCRIPTION
Produces loss of precision warning on 64 bit builds.