### PR TITLE
Fixed incompatible types warning on Unity adapter configuration. 

### DIFF
--- a/UnityAds/UnityAdsAdapterConfiguration.m
+++ b/UnityAds/UnityAdsAdapterConfiguration.m
@@ -77,7 +77,7 @@ typedef NS_ENUM(NSInteger, UnityAdsAdapterErrorCode) {
         complete(nil);
     }
     
-    MPBLogLevel * logLevel = [[MoPub sharedInstance] logLevel];
+    MPBLogLevel logLevel = [[MoPub sharedInstance] logLevel];
     BOOL debugModeEnabled = logLevel == MPBLogLevelDebug;
 
     [UnityAds setDebugMode:debugModeEnabled];


### PR DESCRIPTION
Pointer to enum was being stored when the enum value was desired.