### PR TITLE
Release Unity Ads adapter 3.3.0.1

### DIFF
--- a/UnityAds/CHANGELOG.md
+++ b/UnityAds/CHANGELOG.md
@@ -1,5 +1,9 @@
 
 ## Changelog
+* 3.3.0.1
+  * Update adapter to handle Unity Ads load behaviors seamlessly for fullscreen ads.
+  * Fix incompatible type warning for MoPub `logLevel`. 
+  
 * 3.3.0.0
   * This version of the adapters has been certified with Unity Ads 3.3.0 and is compatible with iOS 13.
   * Update the banner adapter to use new load API.

--- a/UnityAds/UnityAdsAdapterConfiguration.m
+++ b/UnityAds/UnityAdsAdapterConfiguration.m
@@ -14,7 +14,7 @@
 #endif
 
 //Adapter version
-NSString *const ADAPTER_VERSION = @"3.3.0.0";
+NSString *const ADAPTER_VERSION = @"3.3.0.1";
 
 // Initialization configuration keys
 static NSString * const kUnityAdsGameId = @"gameId";
@@ -77,7 +77,7 @@ typedef NS_ENUM(NSInteger, UnityAdsAdapterErrorCode) {
         complete(nil);
     }
     
-    MPBLogLevel * logLevel = [[MoPub sharedInstance] logLevel];
+    MPBLogLevel logLevel = [[MoPub sharedInstance] logLevel];
     BOOL debugModeEnabled = logLevel == MPBLogLevelDebug;
 
     [UnityAds setDebugMode:debugModeEnabled];

--- a/UnityAds/UnityRouter.m
+++ b/UnityAds/UnityRouter.m
@@ -26,9 +26,6 @@
 
 @property NSMutableDictionary* delegateMap;
 
-@property BOOL bannerLoadRequested;
-@property NSString* bannerPlacementId;
-
 @property (nonatomic, assign) int impressionOrdinal;
 @property (nonatomic, assign) int missedImpressionOrdinal;
 
@@ -100,24 +97,12 @@
     //Call load first, to minimize reporting discrepencies
     [UnityAds load:placementId];
     
-    if([UnityAds getPlacementState:placementId] == kUnityAdsPlacementStateNoFill){
-        NSError *error = [NSError errorWithDomain:MoPubRewardedVideoAdsSDKDomain code:MPRewardedVideoAdErrorNoAdsAvailable userInfo:nil];
-        [delegate unityAdsDidFailWithError:error];
-        return;
-    }
-    
     if (!self.isAdPlaying) {
         [self.delegateMap setObject:delegate forKey:placementId];
         
         if (![UnityAds isInitialized]) {
             [self initializeWithGameId:gameId];
         }
-
-        // Need to check immediately as an ad may be cached.
-        if ([UnityAds isReady:placementId]) {
-            [self unityAdsReady:placementId];
-        }
-        // MoPub timeout will handle the case for an ad failing to load.
     } else {
         NSError *error = [NSError errorWithDomain:MoPubRewardedVideoAdsSDKDomain code:MPRewardedVideoAdErrorUnknown userInfo:nil];
         [delegate unityAdsDidFailWithError:error];
@@ -167,9 +152,7 @@
 
 - (void)unityAdsReady:(NSString *)placementId
 {
-    if ([placementId isEqualToString:self.bannerPlacementId] && self.bannerLoadRequested) {
-        self.bannerLoadRequested = NO;
-    } else if (!self.isAdPlaying) {
+    if (!self.isAdPlaying) {
         id delegate = [self getDelegate:placementId];
         if (delegate != nil) {
             [delegate unityAdsReady:placementId];


### PR DESCRIPTION
Currently, Unity SDK has two different behaviors for loading ads: 
1. request and caching full screen ads for all placements right after SDK initialized.
2. request ads for one placement by the time call load.

This PR is to change Unity Adapter to handle this better.

Unity SDK will trigger UnityRouterDelegate every time ` [UnityAds load:placementId];` is called for both behaviors and adapter will handle both  seamless. 

NOTE:
This feature will be only apply for adapters with specific versions, e.g. 3.3.0.1.  