### PR TITLE
AppLovin - Fix compiler warnings - 6.10.2.0

### DIFF
--- a/AppLovin/AppLovinAdapterConfiguration.m
+++ b/AppLovin/AppLovinAdapterConfiguration.m
@@ -20,7 +20,7 @@ static ALSdk *__nullable AppLovinAdapterConfigurationSDK;
 
 static NSString *const kAppLovinSDKInfoPlistKey = @"AppLovinSdkKey";
 static NSString *const kAdapterErrorDomain = @"com.mopub.mopub-ios-sdk.mopub-applovin-adapters";
-static NSString *const kAdapterVersion = @"6.10.1.0";
+static NSString *const kAdapterVersion = @"6.10.1.1";
 
 static NSString *gSdkKey = nil;
 

--- a/AppLovin/AppLovinAdapterConfiguration.m
+++ b/AppLovin/AppLovinAdapterConfiguration.m
@@ -20,7 +20,7 @@ static ALSdk *__nullable AppLovinAdapterConfigurationSDK;
 
 static NSString *const kAppLovinSDKInfoPlistKey = @"AppLovinSdkKey";
 static NSString *const kAdapterErrorDomain = @"com.mopub.mopub-ios-sdk.mopub-applovin-adapters";
-static NSString *const kAdapterVersion = @"6.10.1.1";
+static NSString *const kAdapterVersion = @"6.10.2.0";
 
 static NSString *gSdkKey = nil;
 

--- a/AppLovin/AppLovinBannerCustomEvent.m
+++ b/AppLovin/AppLovinBannerCustomEvent.m
@@ -94,7 +94,7 @@ static NSMutableDictionary<NSString *, ALAdView *> *ALGlobalAdViews;
     zoneIdentifier = ZONE_FROM_INFO(info);
     
     // Create adview based off of zone (if any)
-    self.adView = [[self class] adViewForFrame: CGRectMake(0, 0, adSize.width, adSize.height)
+    self.adView = [[self class] adViewForFrame: [self rectFromAppLovinAdSize: adSize]
                                         adSize: adSize
                                 zoneIdentifier: zoneIdentifier
                                    customEvent: self
@@ -128,17 +128,31 @@ static NSMutableDictionary<NSString *, ALAdView *> *ALGlobalAdViews;
 - (ALAdSize *)appLovinAdSizeFromRequestedSize:(CGSize)size
 {
     // Default to standard banner size
-    ALAdSize * adSize = [ALAdSize sizeBanner];
+    ALAdSize * adSize = ALAdSize.banner;
     
     // Size can contain an AppLovin leaderboard ad size of 728x90
     if (size.width >= 728 && size.height >= 90) {
-        adSize = [ALAdSize sizeLeader];
+        adSize = ALAdSize.leader;
     } else if (size.width >= 300 && size.height >= 250) {
         // Size can contain an AppLovin medium rectangle
-        adSize = [ALAdSize sizeMRec];
+        adSize = ALAdSize.mrec;
     }
     
     return adSize;
+}
+
+- (CGRect)rectFromAppLovinAdSize:(ALAdSize *)alAdSize
+{
+    // Default to standard banner size
+    CGRect adRect = CGRectMake(0, 0, 320, 50);
+    
+    if (alAdSize == ALAdSize.leader) {
+        adRect = CGRectMake(0, 0, 728, 90);
+    } else if (alAdSize == ALAdSize.mrec) {
+        adRect = CGRectMake(0, 0, 300, 250);
+    }
+    
+    return adRect;
 }
 
 - (MOPUBErrorCode)toMoPubErrorCode:(int)appLovinErrorCode

--- a/AppLovin/CHANGELOG.md
+++ b/AppLovin/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Changelog
+   * 6.10.1.1
+     * Fix compiler warnings.
+
    * 6.10.1.0
      * This version of the adapters has been certified with AppLovin SDK 6.10.1.
 

--- a/AppLovin/CHANGELOG.md
+++ b/AppLovin/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
-   * 6.10.1.1
+   * 6.10.2.0
+     * This version of the adapters has been certified with AppLovin SDK 6.10.2.
      * Fix compiler warnings.
 
    * 6.10.1.0


### PR DESCRIPTION
There were several compiler warnings due to recently deprecated properties and functions in ALAdSize.