### PR TITLE
Various Tapjoy Adapter Changes/Fixes

### DIFF
--- a/FacebookAudienceNetwork/FacebookAdapterConfiguration.m
+++ b/FacebookAudienceNetwork/FacebookAdapterConfiguration.m
@@ -96,7 +96,8 @@ static Boolean *sIsNativeBanner = nil;
      }];
 
     if (configuration != nil && [configuration count] > 0) {
-        FacebookAdapterConfiguration.isNativeBanner = [[configuration objectForKey:@"native_banner"] boolValue];
+        id const nativeBannerValue = [configuration objectForKey:@"native_banner"];
+        FacebookAdapterConfiguration.isNativeBanner = nativeBannerValue ? (Boolean *)[nativeBannerValue boolValue] : nil;
     }
 
 }

--- a/FacebookAudienceNetwork/FacebookNativeCustomEvent.m
+++ b/FacebookAudienceNetwork/FacebookNativeCustomEvent.m
@@ -22,7 +22,7 @@ static const NSInteger FacebookNoFillErrorCode = 1001;
 @property (nonatomic, readwrite, strong) FBNativeAdBase *fbNativeAdBase;
 
 @property (nonatomic, copy) NSString *fbPlacementId;
-@property (nonatomic) Boolean isNativeBanner;
+@property (nonatomic) Boolean *isNativeBanner;
 
 @end
 
@@ -39,7 +39,8 @@ static const NSInteger FacebookNoFillErrorCode = 1001;
 
     if (self.fbPlacementId) {
         if (self.localExtras != nil && [self.localExtras count] > 0) {
-            self.isNativeBanner = [[self.localExtras objectForKey:@"native_banner"] boolValue];
+            id const nativeBannerValue = [self.localExtras objectForKey:@"native_banner"];
+            self.isNativeBanner = nativeBannerValue ? (Boolean *)[nativeBannerValue boolValue] : nil;
         }
         
         self.isNativeBanner = self.isNativeBanner == nil ? FacebookAdapterConfiguration.isNativeBanner : self.isNativeBanner;


### PR DESCRIPTION
1. Changes to the `debugEnabled` behaviour

Per the Tapjoy documentation (https://dev.tapjoy.com/sdk-integration/ios/getting-started-guide-publishers-ios/), calls to `+[Tapjoy setDebugEnabled:]` should be performed before the call to `+[Tapjoy connect:options:]`. Specifically, "method’s setDebugEnabled and setUserID should be defined before the connect call."

This pull request moves calls to `+[Tapjoy setDebugEnabled:]` to before any connect calls.

Additionally, the adapter configuration was basing Tapjoy's debugging on the current MoPub log level, not the value of `enableDebug` which is based on the `kTapjoyDebugEnabled` key within the network configuration. I believe that it makes more sense for the adapter to enable Tapjoy debugging based on the network configuration rather than the MoPub log level.

2. Exposing `kTapjoySdkKey` and `kTapjoyDebugEnabled` within the adapter configuration header file

When using `-[setNetworkConfiguration:forMediationAdapter:]` on a MoPub configuration, one can use these constants to set the SDK key and enable/disable debugging instead of having to manually find the string values of these constants and use those.