### PR TITLE
Chartboost SDK 8.1.0

### DIFF
--- a/Chartboost/CHANGELOG.md
+++ b/Chartboost/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Changelog
+  * 8.1.0.0
+     * This version of the adapters has been certified with Chartboost 8.1.0 and is compatible with multiple Chartboost instances.
+      
   * 8.0.4.0
       * This version of the adapters has been certified with Chartboost 8.0.4.
 

--- a/Chartboost/ChartboostAdapterConfiguration.h
+++ b/Chartboost/ChartboostAdapterConfiguration.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)initializeNetworkWithConfiguration:(NSDictionary<NSString *, id> * _Nullable)configuration
                                   complete:(void(^ _Nullable)(NSError * _Nullable))complete;
 
-+ (NSString*)mediationString;
++ (NSString *)adapterVersion;
 
 @end
 

--- a/Chartboost/ChartboostAdapterConfiguration.m
+++ b/Chartboost/ChartboostAdapterConfiguration.m
@@ -1,13 +1,10 @@
-#import <Chartboost/Chartboost.h>
 #import "ChartboostAdapterConfiguration.h"
 #import "ChartboostRouter.h"
-
 #if __has_include("MoPub.h")
-#import "MoPub.h"
 #import "MPLogging.h"
 #endif
 
-#define CHARTBOOST_ADAPTER_VERSION             @"8.0.4.0"
+#define CHARTBOOST_ADAPTER_VERSION             @"8.1.0.0"
 #define MOPUB_NETWORK_NAME                     @"chartboost"
 
 // Constants
@@ -27,14 +24,13 @@ typedef NS_ENUM(NSInteger, ChartboostAdapterErrorCode) {
 #pragma mark - Caching
 
 + (void)updateInitializationParameters:(NSDictionary *)parameters {
-    // These should correspond to the required parameters checked in
-    // `initializeNetworkWithConfiguration:complete:`
-    NSString * appId = parameters[kChartboostAppIdKey];
-    NSString * appSignature = parameters[kChartboostAppSignatureKey];
+    // These should correspond to the required parameters checked in `initializeNetworkWithConfiguration:complete:`
+    NSString *appId = parameters[kChartboostAppIdKey];
+    NSString *appSignature = parameters[kChartboostAppSignatureKey];
     
     if (appId != nil && appSignature != nil) {
-        NSDictionary * configuration = @{ kChartboostAppIdKey: appId, kChartboostAppSignatureKey:appSignature };
-        [ChartboostAdapterConfiguration setCachedInitializationParameters:configuration];
+        [ChartboostAdapterConfiguration setCachedInitializationParameters: @{kChartboostAppIdKey: appId,
+                                                                             kChartboostAppSignatureKey: appSignature}];
     }
 }
 
@@ -57,11 +53,24 @@ typedef NS_ENUM(NSInteger, ChartboostAdapterErrorCode) {
 }
 
 - (void)initializeNetworkWithConfiguration:(NSDictionary<NSString *, id> *)configuration
-                                  complete:(void(^)(NSError *))complete {
-    
-    NSString * appId = configuration[kChartboostAppIdKey];
-    if (appId == nil) {
-        NSError * error = [NSError errorWithDomain:kAdapterErrorDomain code:ChartboostAdapterErrorCodeMissingAppId userInfo:@{ NSLocalizedDescriptionKey: @"Chartboost's initialization skipped. The appId is empty. Ensure it is properly configured on the MoPub dashboard. Note that initialization on the first app launch is a no-op." }];
+                                  complete:(void(^)(NSError *))complete
+{
+    // configuration may not have credentials info on the first app launch. See https://developers.mopub.com/publishers/ios/initialize/
+    if (configuration[kChartboostAppIdKey] == nil) {
+        NSError *error = [NSError errorWithDomain:kAdapterErrorDomain
+                                             code:ChartboostAdapterErrorCodeMissingAppId
+                                         userInfo:@{ NSLocalizedDescriptionKey: @"Chartboost's initialization skipped. The appId is empty. Ensure it is properly configured on the MoPub dashboard. Note that initialization on the first app launch is a no-op." }];
+        MPLogEvent([MPLogEvent error:error message:nil]);
+        
+        if (complete != nil) {
+            complete(error);
+        }
+        return;
+    }
+    if (configuration[kChartboostAppSignatureKey] == nil) {
+        NSError *error = [NSError errorWithDomain:kAdapterErrorDomain
+                                             code:ChartboostAdapterErrorCodeMissingAppSignature
+                                         userInfo:@{ NSLocalizedDescriptionKey: @"Chartboost's initialization skipped. The appSignature is empty. Ensure it is properly configured on the MoPub dashboard. Note that initialization on the first app launch is a no-op." }];
         MPLogEvent([MPLogEvent error:error message:nil]);
         
         if (complete != nil) {
@@ -70,42 +79,17 @@ typedef NS_ENUM(NSInteger, ChartboostAdapterErrorCode) {
         return;
     }
     
-    NSString * appSignature = configuration[kChartboostAppSignatureKey];
-    if (appSignature == nil) {
-        NSError * error = [NSError errorWithDomain:kAdapterErrorDomain code:ChartboostAdapterErrorCodeMissingAppSignature userInfo:@{ NSLocalizedDescriptionKey: @"Chartboost's initialization skipped. The appSignature is empty. Ensure it is properly configured on the MoPub dashboard. Note that initialization on the first app launch is a no-op." }];
-        MPLogEvent([MPLogEvent error:error message:nil]);
-        
-        if (complete != nil) {
-            complete(error);
-        }
-        return;
-    }
+    [ChartboostRouter setDataUseConsentWithMopubConfiguration];
+    [ChartboostRouter setLoggingLevel:[MPLogging consoleLogLevel]];
     
-    // Initialize the router
-    [[ChartboostRouter sharedRouter] startWithAppId:appId appSignature:appSignature completion:^(BOOL initialized) {
+    [ChartboostRouter startWithParameters:configuration completion:^(BOOL initialized) {
         if (complete != nil) {
             complete(nil);
         }
     }];
-    
-    MPBLogLevel mopubLogLevel = [MPLogging consoleLogLevel];
-    CBLoggingLevel chartboostLogLevel = [ChartboostAdapterConfiguration getChartboostLogLevel:mopubLogLevel];
-    [Chartboost setLoggingLevel:chartboostLogLevel];
 }
 
-+ (CBLoggingLevel)getChartboostLogLevel:(MPBLogLevel)logLevel
-{
-    switch (logLevel) {
-        case MPBLogLevelDebug:
-            return CBLoggingLevelVerbose;
-        case MPBLogLevelInfo:
-            return CBLoggingLevelInfo;
-        default:
-            return CBLoggingLevelOff;
-    }
-}
-
-+ (NSString*)mediationString
++ (NSString *)adapterVersion
 {
     return CHARTBOOST_ADAPTER_VERSION;
 }

--- a/Chartboost/ChartboostBannerCustomEvent.m
+++ b/Chartboost/ChartboostBannerCustomEvent.m
@@ -63,15 +63,9 @@
     }
 }
 
-- (void)willShowAd:(CHBShowEvent *)event error:(nullable CHBShowError *)error
+- (void)willShowAd:(CHBShowEvent *)event
 {
-    if (error) {
-        NSError *nserror = [NSError errorWithShowEvent:event error:error];
-        MPLogAdEvent([MPLogEvent adShowFailedForAdapter:NSStringFromClass(self.class) error:nserror], event.ad.location);
-        [self.delegate bannerCustomEvent:self didFailToLoadAdWithError:nserror];
-    } else {
-        MPLogAdEvent([MPLogEvent adShowAttemptForAdapter:NSStringFromClass(self.class)], event.ad.location);
-    }
+    MPLogAdEvent([MPLogEvent adShowAttemptForAdapter:NSStringFromClass(self.class)], event.ad.location);
 }
 
 - (void)didShowAd:(CHBShowEvent *)event error:(nullable CHBShowError *)error

--- a/Chartboost/ChartboostBannerCustomEvent.m
+++ b/Chartboost/ChartboostBannerCustomEvent.m
@@ -6,58 +6,38 @@
 //
 
 #import "ChartboostBannerCustomEvent.h"
-#import "ChartboostAdapterConfiguration.h"
 #import "ChartboostRouter.h"
-#if __has_include("MoPub.h")
-    #import "MPLogging.h"
-#endif
-#import <Chartboost/Chartboost.h>
-#import <Chartboost/CHBBanner.h>
+#import "NSError+ChartboostErrors.h"
 
 @interface ChartboostBannerCustomEvent () <CHBBannerDelegate>
-
 @property (nonatomic) CHBBanner *banner;
-@property (nonatomic, copy) NSString *appID;
-
 @end
 
 @implementation ChartboostBannerCustomEvent
 
 - (void)requestAdWithSize:(CGSize)size customEventInfo:(NSDictionary *)info adMarkup:(NSString *)adMarkup
 {
-    self.appID = [info objectForKey:@"appId"];
-    NSString *appSignature = [info objectForKey:@"appSignature"];
-    MPLogAdEvent([MPLogEvent adLoadAttemptForAdapter:NSStringFromClass(self.class) dspCreativeId:nil dspName:nil], self.appID);
-    
-    if ([self.appID length] == 0 || [appSignature length] == 0) {
-        NSError *error = [NSError errorWithCode:MOPUBErrorAdapterInvalid localizedDescription:@"Failed to load Chartboost banner: missing either appId or appSignature. Make sure you have a valid appId or appSignature entered on the MoPub dashboard."];
-        MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:error], self.appID);
-        [self.delegate bannerCustomEvent:self didFailToLoadAdWithError:error];
-        
-        return;
-    }
-    
-    if (self.banner) {
-        NSError *error = [NSError errorWithCode:MOPUBErrorAdapterInvalid localizedDescription:@"Chartboost adapter failed to load ad: requestAdWithSize called twice on the same event."];
-        MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:error], self.appID);
-        [self.delegate bannerCustomEvent:self didFailToLoadAdWithError:error];
-        
-        return;
-    }
-    
-    [ChartboostAdapterConfiguration updateInitializationParameters:info];
-    
     NSString *location = [info objectForKey:@"location"];
-    location = [location length] != 0 ? location: CBLocationDefault;
+    location = location.length > 0 ? location : CBLocationDefault;
     CGSize integerSize = CGSizeMake(floor(size.width), floor(size.height));
+
+    MPLogAdEvent([MPLogEvent adLoadAttemptForAdapter:NSStringFromClass(self.class) dspCreativeId:nil dspName:nil], location);
+    if (self.banner) {
+        MPLogAdEvent([MPLogEvent error:[NSError adRequestCalledTwiceOnSameEvent] message:nil], location);
+    }
     
     __weak typeof(self) weakSelf = self;
-    [[ChartboostRouter sharedRouter] startWithAppId:self.appID appSignature:appSignature completion:^(BOOL initialized) {
+    [ChartboostRouter startWithParameters:info completion:^(BOOL initialized) {
+        if (!initialized) {
+            NSError *error = [NSError adRequestFailedDueToSDKStartWithAdOfType:@"banner"];
+            MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:error], location);
+            [self.delegate bannerCustomEvent:self didFailToLoadAdWithError:error];
+            return;
+        }
         dispatch_async(dispatch_get_main_queue(), ^{
-            if (!weakSelf.banner) {
-                weakSelf.banner = [[CHBBanner alloc] initWithSize:integerSize location:location delegate:weakSelf];
-                weakSelf.banner.automaticallyRefreshesContent = NO;
-            }
+            weakSelf.banner.delegate = nil;
+            weakSelf.banner = [[CHBBanner alloc] initWithSize:integerSize location:location mediation:[ChartboostRouter mediation] delegate:weakSelf];
+            weakSelf.banner.automaticallyRefreshesContent = NO;
             
             [weakSelf.banner showFromViewController:[weakSelf.delegate viewControllerForPresentingModalView]];
         });
@@ -66,7 +46,7 @@
 
 - (BOOL)enableAutomaticImpressionAndClickTracking
 {
-    return NO;
+    return NO;  // Disabled so we have control over the click tracking behavior
 }
 
 // MARK: - CHBBannerDelegate
@@ -74,11 +54,11 @@
 - (void)didCacheAd:(CHBCacheEvent *)event error:(nullable CHBCacheError *)error
 {
     if (error) {
-        NSError *nserror = [self errorWithCacheError:error];
-        MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:nserror], self.appID);
+        NSError *nserror = [NSError errorWithCacheEvent:event error:error];
+        MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:nserror], event.ad.location);
         [self.delegate bannerCustomEvent:self didFailToLoadAdWithError:nserror];
     } else {
-        MPLogAdEvent([MPLogEvent adLoadSuccessForAdapter:NSStringFromClass(self.class)], self.appID);
+        MPLogAdEvent([MPLogEvent adLoadSuccessForAdapter:NSStringFromClass(self.class)], event.ad.location);
         [self.delegate bannerCustomEvent:self didLoadAd:self.banner];
     }
 }
@@ -86,22 +66,22 @@
 - (void)willShowAd:(CHBShowEvent *)event error:(nullable CHBShowError *)error
 {
     if (error) {
-        NSError *nserror = [self errorWithShowError:error];
-        MPLogAdEvent([MPLogEvent adShowFailedForAdapter:NSStringFromClass(self.class) error:nserror], self.appID);
+        NSError *nserror = [NSError errorWithShowEvent:event error:error];
+        MPLogAdEvent([MPLogEvent adShowFailedForAdapter:NSStringFromClass(self.class) error:nserror], event.ad.location);
         [self.delegate bannerCustomEvent:self didFailToLoadAdWithError:nserror];
     } else {
-        MPLogAdEvent([MPLogEvent adShowAttemptForAdapter:NSStringFromClass(self.class)], self.appID);
+        MPLogAdEvent([MPLogEvent adShowAttemptForAdapter:NSStringFromClass(self.class)], event.ad.location);
     }
 }
 
 - (void)didShowAd:(CHBShowEvent *)event error:(nullable CHBShowError *)error
 {
     if (error) {
-        NSError *nserror = [self errorWithShowError:error];
-        MPLogAdEvent([MPLogEvent adShowFailedForAdapter:NSStringFromClass(self.class) error:nserror], self.appID);
+        NSError *nserror = [NSError errorWithShowEvent:event error:error];
+        MPLogAdEvent([MPLogEvent adShowFailedForAdapter:NSStringFromClass(self.class) error:nserror], event.ad.location);
         [self.delegate bannerCustomEvent:self didFailToLoadAdWithError:nserror];
     } else {
-        MPLogAdEvent([MPLogEvent adShowSuccessForAdapter:NSStringFromClass(self.class)], self.appID);
+        MPLogAdEvent([MPLogEvent adShowSuccessForAdapter:NSStringFromClass(self.class)], event.ad.location);
         [self.delegate trackImpression];
     }
 }
@@ -109,56 +89,22 @@
 - (void)didClickAd:(CHBClickEvent *)event error:(nullable CHBClickError *)error
 {
     if (error) {
-        NSError *nserror = [self errorWithClickError:error];
-        MPLogAdEvent([MPLogEvent error:nserror message:nil], self.appID);
+        NSError *nserror = [NSError errorWithClickEvent:event error:error];
+        MPLogAdEvent([MPLogEvent error:nserror message:nil], event.ad.location);
     } else {
-        MPLogAdEvent([MPLogEvent adTappedForAdapter:NSStringFromClass(self.class)], self.appID);
         [self.delegate bannerCustomEventWillBeginAction:self];
-        [self.delegate trackClick];
     }
+    MPLogAdEvent([MPLogEvent adTappedForAdapter:NSStringFromClass(self.class)], event.ad.location);
+    [self.delegate trackClick]; // We track the click even if there was an error, since we want to track events like when an ad passes an invalid url
 }
 
 - (void)didFinishHandlingClick:(CHBClickEvent *)event error:(nullable CHBClickError *)error
 {
     if (error) {
-        NSError *nserror = [self errorWithClickHandlingError:error];
-        MPLogAdEvent([MPLogEvent error:nserror message:nil], self.appID);
+        NSError *nserror = [NSError errorWithDidFinishHandlingClickEvent:event error:error];
+        MPLogAdEvent([MPLogEvent error:nserror message:nil], event.ad.location);
     }
     [self.delegate bannerCustomEventDidFinishAction:self];
-}
-
-// MARK: - Helpers
-
-- (NSError *)errorWithCacheError:(CHBCacheError *)error
-{
-    NSString *description = [NSString stringWithFormat:@"Chartboost adapter failed to load ad with error %lu", (unsigned long)error.code];
-    NSError *nserror = [NSError errorWithCode:MOPUBErrorAdapterFailedToLoadAd localizedDescription:description];
-    
-    return nserror;
-}
-
-- (NSError *)errorWithShowError:(CHBShowError *)error
-{
-    NSString *description = [NSString stringWithFormat:@"Chartboost adapter failed to show ad with error %lu", (unsigned long)error.code];
-    NSError *nserror = [NSError errorWithCode:MOPUBErrorAdapterFailedToLoadAd localizedDescription:description];
-    
-    return nserror;
-}
-
-- (NSError *)errorWithClickError:(CHBClickError *)error
-{
-    NSString *description = [NSString stringWithFormat:@"Chartboost adapter failed to click ad with error %lu", (unsigned long)error.code];
-    NSError *nserror = [NSError errorWithCode:MOPUBErrorUnknown localizedDescription:description];
-    
-    return nserror;
-}
-
-- (NSError *)errorWithClickHandlingError:(CHBClickError *)error
-{
-    NSString *description = [NSString stringWithFormat:@"Chartboost adapter did finish handling click with error %lu", (unsigned long)error.code];
-    NSError *nserror = [NSError errorWithCode:MOPUBErrorUnknown localizedDescription:description];
-    
-    return nserror;
 }
 
 @end

--- a/Chartboost/ChartboostInterstitialCustomEvent.h
+++ b/Chartboost/ChartboostInterstitialCustomEvent.h
@@ -15,44 +15,4 @@
 
 
 @interface ChartboostInterstitialCustomEvent : MPInterstitialCustomEvent
-
-/**
- * A string that corresponds to a Chartboost CBLocation used for differentiating ad requests.
- */
-@property (nonatomic, copy) NSString *location;
-
-/**
- * Registers a Chartboost app ID to be used when initializing the Chartboost SDK.
- *
- * At initialization, the Chartboost SDK requires you to provide your Chartboost app ID. When
- * integrating Chartboost using a MoPub custom event, this ID is typically configured via your
- * Chartboost network settings on the MoPub website. However, if you wish, you may use this method to
- * manually provide the custom event with your app ID.
- *
- * IMPORTANT: If you choose to use this method, be sure to call it before making any ad requests,
- * and avoid calling it more than once. Otherwise, the Chartboost SDK may be initialized improperly.
- *
- * **Deprecated**: This method of setting the Chartboost app ID is deprecated. Use the MoPub website
- * to set your app ID in your network settings for Chartboost. See the Custom Native Network Setup guide for more
- * information. https://dev.twitter.com/mopub/ad-networks/network-setup-custom-native
- */
-+ (void)setAppId:(NSString *)appId;
-
-/**
- * Registers a Chartboost app signature to be used when initializing the Chartboost SDK.
- *
- * At initialization, the Chartboost SDK requires you to provide your Chartboost app signature. When
- * integrating Chartboost using a MoPub custom event, this value is typically configured via your
- * Chartboost network settings on the MoPub website. However, if you wish, you may use this method to
- * manually provide the custom event with your app signature.
- *
- * IMPORTANT: If you choose to use this method, be sure to call it before making any ad requests,
- * and avoid calling it more than once. Otherwise, the Chartboost SDK may be initialized improperly.
- *
- * **Deprecated**: This method of setting the Chartboost app signature is deprecated. Use the MoPub website
- * to set your app signature in your network settings for Chartboost. See the Custom Native Network Setup guide for more
- * information. https://dev.twitter.com/mopub/ad-networks/network-setup-custom-native
- */
-+ (void)setAppSignature:(NSString *)appSignature;
-
 @end

--- a/Chartboost/ChartboostInterstitialCustomEvent.m
+++ b/Chartboost/ChartboostInterstitialCustomEvent.m
@@ -62,16 +62,10 @@
     }
 }
 
-- (void)willShowAd:(CHBShowEvent *)event error:(CHBShowError *)error
+- (void)willShowAd:(CHBShowEvent *)event
 {
-    if (error) {
-        NSError *nserror = [NSError errorWithShowEvent:event error:error];
-        MPLogAdEvent([MPLogEvent adShowFailedForAdapter:NSStringFromClass(self.class) error:nserror], event.ad.location);
-        [self.delegate interstitialCustomEvent:self didFailToLoadAdWithError:nserror];
-    } else {
-        MPLogAdEvent([MPLogEvent adWillAppearForAdapter:NSStringFromClass(self.class)], event.ad.location);
-        [self.delegate interstitialCustomEventWillAppear:self];
-    }
+    MPLogAdEvent([MPLogEvent adWillAppearForAdapter:NSStringFromClass(self.class)], event.ad.location);
+    [self.delegate interstitialCustomEventWillAppear:self];
 }
 
 - (void)didShowAd:(CHBShowEvent *)event error:(CHBShowError *)error

--- a/Chartboost/ChartboostInterstitialCustomEvent.m
+++ b/Chartboost/ChartboostInterstitialCustomEvent.m
@@ -6,159 +6,103 @@
 //
 
 #import "ChartboostInterstitialCustomEvent.h"
-#import "ChartboostAdapterConfiguration.h"
-#if __has_include("MoPub.h")
-    #import "MPLogging.h"
-#endif
 #import "ChartboostRouter.h"
-#import <Chartboost/Chartboost.h>
+#import "NSError+ChartboostErrors.h"
 
-static NSString *appId = nil;
-
-#define kChartboostAppID        @"YOUR_CHARTBOOST_APP_ID"
-#define kChartboostAppSignature @"YOUR_CHARTBOOST_APP_SIGNATURE"
-
-@interface ChartboostInterstitialCustomEvent () <ChartboostDelegate>
+@interface ChartboostInterstitialCustomEvent() <CHBInterstitialDelegate>
+@property (nonatomic) CHBInterstitial *ad;
 @end
 
 @implementation ChartboostInterstitialCustomEvent
 
-+ (void)setAppId:(NSString *)appId
-{
-    MPLogInfo(@"+setAppId for class ChartboostInterstitialCustomEvent is deprecated. Use the appId parameter when configuring your network in the MoPub UI.");
-}
-
-+ (void)setAppSignature:(NSString *)appSignature
-{
-    MPLogInfo(@"+setAppSignature for class ChartboostInterstitialCustomEvent is deprecated. Use the appSignature parameter when configuring your network in the MoPub UI.");
-}
-
-- (void)invalidate
-{
-    [[ChartboostRouter sharedRouter] unregisterInterstitialEvent:self];
-    self.location = nil;
-}
-
-#pragma mark - MPInterstitialCustomEvent Subclass Methods
+#pragma mark - MPInterstitialCustomEvent
 
 - (void)requestInterstitialWithCustomEventInfo:(NSDictionary *)info adMarkup:(NSString *)adMarkup
 {
-    appId = [info objectForKey:@"appId"];
-    if (!appId) {
-
-        if ([appId length] == 0) {
-            MPLogInfo(@"Setting kChartboostAppId in ChartboostInterstitialCustomEvent.m is deprecated. Use the appId parameter when configuring your network in the MoPub UI.");
-            appId = kChartboostAppID;
-        }
-    }
-    NSString *appSignature = [info objectForKey:@"appSignature"];
-    if (!appSignature) {
-
-        if ([appSignature length] == 0) {
-            MPLogInfo(@"Setting kChartboostAppSignature in ChartboostInterstitialCustomEvent.m is deprecated. Use the appSignature parameter when configuring your network in the MoPub UI.");
-            appSignature = kChartboostAppSignature;
-        }
-    }
     NSString *location = [info objectForKey:@"location"];
-    self.location = [location length] != 0 ? location : CBLocationDefault;
-    
-    // Cache the network SDK initialization parameters
-    [ChartboostAdapterConfiguration updateInitializationParameters:info];
+    location = location.length > 0 ? location : CBLocationDefault;
 
-    [[ChartboostRouter sharedRouter] cacheInterstitialWithAppId:appId
-                                                     appSignature:appSignature
-                                                         location:self.location
-                             forChartboostInterstitialCustomEvent:self];
+    MPLogAdEvent([MPLogEvent adLoadAttemptForAdapter:NSStringFromClass(self.class) dspCreativeId:nil dspName:nil], location);
+    if (self.ad) {
+        MPLogAdEvent([MPLogEvent error:[NSError adRequestCalledTwiceOnSameEvent] message:nil], location);
+    }
+    
+    __weak typeof(self) weakSelf = self;
+    [ChartboostRouter startWithParameters:info completion:^(BOOL initialized) {
+        if (!initialized) {
+            NSError *error = [NSError adRequestFailedDueToSDKStartWithAdOfType:@"interstitial"];
+            MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:error], location);
+            [self.delegate interstitialCustomEvent:self didFailToLoadAdWithError:error];
+            return;
+        }
+        
+        weakSelf.ad.delegate = nil;
+        weakSelf.ad = [[CHBInterstitial alloc] initWithLocation:location mediation:[ChartboostRouter mediation] delegate:weakSelf];
+        [weakSelf.ad cache];
+    }];
 }
 
-- (void)showInterstitialFromRootViewController:(UIViewController *)rootViewController
+- (void)showInterstitialFromRootViewController:(UIViewController *)viewController
 {
-    MPLogAdEvent([MPLogEvent adShowAttemptForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
+    MPLogAdEvent([MPLogEvent adShowAttemptForAdapter:NSStringFromClass(self.class)], self.ad.location);
+    [self.ad showFromViewController:viewController];
+}
 
-    if ([[ChartboostRouter sharedRouter] hasCachedInterstitialForLocation:self.location]) {
+#pragma mark - CHBInterstitialDelegate
 
-        [[ChartboostRouter sharedRouter] showInterstitialForLocation:self.location];
-    } else {        
-        NSError *error = [self createErrorWith:@"Failed to show Chartboost interstitial"
-                                     andReason:@""
-                                 andSuggestion:@""];
-        
-        [self.delegate interstitialCustomEvent:self didFailToLoadAdWithError:error];
-        MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:error], [self getAdNetworkId]);
+- (void)didCacheAd:(CHBCacheEvent *)event error:(CHBCacheError *)error
+{
+    if (error) {
+        NSError *nserror = [NSError errorWithCacheEvent:event error:error];
+        MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:nserror], event.ad.location);
+        [self.delegate interstitialCustomEvent:self didFailToLoadAdWithError:nserror];
+    } else {
+        MPLogAdEvent([MPLogEvent adLoadSuccessForAdapter:NSStringFromClass(self.class)], event.ad.location);
+        [self.delegate interstitialCustomEvent:self didLoadAd:nil];
     }
 }
 
-- (NSError *)createErrorWith:(NSString *)description andReason:(NSString *)reaason andSuggestion:(NSString *)suggestion {
-    NSDictionary *userInfo = @{
-                               NSLocalizedDescriptionKey: NSLocalizedString(description, nil),
-                               NSLocalizedFailureReasonErrorKey: NSLocalizedString(reaason, nil),
-                               NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(suggestion, nil)
-                               };
-
-    return [NSError errorWithDomain:NSStringFromClass([self class]) code:0 userInfo:userInfo];
+- (void)willShowAd:(CHBShowEvent *)event error:(CHBShowError *)error
+{
+    if (error) {
+        NSError *nserror = [NSError errorWithShowEvent:event error:error];
+        MPLogAdEvent([MPLogEvent adShowFailedForAdapter:NSStringFromClass(self.class) error:nserror], event.ad.location);
+        [self.delegate interstitialCustomEvent:self didFailToLoadAdWithError:nserror];
+    } else {
+        MPLogAdEvent([MPLogEvent adWillAppearForAdapter:NSStringFromClass(self.class)], event.ad.location);
+        [self.delegate interstitialCustomEventWillAppear:self];
+    }
 }
 
-#pragma mark - ChartboostDelegate
-
-- (void)didCacheInterstitial:(CBLocation)location
+- (void)didShowAd:(CHBShowEvent *)event error:(CHBShowError *)error
 {
-    MPLogInfo(@"Successfully loaded Chartboost interstitial. Location: %@", location);
-
-    [self.delegate interstitialCustomEvent:self didLoadAd:nil];
-    MPLogAdEvent([MPLogEvent adLoadSuccessForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
+    if (error) {
+        NSError *nserror = [NSError errorWithShowEvent:event error:error];
+        MPLogAdEvent([MPLogEvent adShowFailedForAdapter:NSStringFromClass(self.class) error:nserror], self.ad.location);
+        [self.delegate interstitialCustomEvent:self didFailToLoadAdWithError:nserror];
+    } else {
+        MPLogAdEvent([MPLogEvent adShowSuccessForAdapter:NSStringFromClass(self.class)], event.ad.location);
+        MPLogAdEvent([MPLogEvent adDidAppearForAdapter:NSStringFromClass(self.class)], event.ad.location);
+        [self.delegate interstitialCustomEventDidAppear:self];
+    }
 }
 
-- (void)didFailToLoadInterstitial:(CBLocation)location withError:(CBLoadError)error
+- (void)didClickAd:(CHBClickEvent *)event error:(CHBClickError *)error
 {
-    NSString *failureReason = [NSString stringWithFormat:@"Failed to load Chartboost interstitial. Location: %@", location];
-    NSError *mopubError = [self createErrorWith:failureReason
-                                 andReason:@""
-                             andSuggestion:@""];
-
-    [self.delegate interstitialCustomEvent:self didFailToLoadAdWithError:mopubError];
-    MPLogAdEvent([MPLogEvent adShowFailedForAdapter:NSStringFromClass(self.class) error:mopubError], [self getAdNetworkId]);
-}
-
-- (void)didDismissInterstitial:(CBLocation)location
-{
-    MPLogAdEvent([MPLogEvent adWillDisappearForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
-
-    MPLogInfo(@"Chartboost interstitial was dismissed. Location: %@", location);
-
-    // Chartboost doesn't seem to have a separate callback for the "will disappear" event, so we
-    // signal "will disappear" manually.
-
-    [self.delegate interstitialCustomEventWillDisappear:self];
-    [self.delegate interstitialCustomEventDidDisappear:self];
-
-    MPLogAdEvent([MPLogEvent adDidDisappearForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
-}
-
-- (void)didDisplayInterstitial:(CBLocation)location
-{
-    MPLogInfo(@"Chartboost interstitial was displayed. Location: %@", location);
-
-    // Chartboost doesn't seem to have a separate callback for the "will appear" event, so we
-    // signal "will appear" manually.
-
-    [self.delegate interstitialCustomEventWillAppear:self];
-    [self.delegate interstitialCustomEventDidAppear:self];
-    
-    MPLogAdEvent([MPLogEvent adWillAppearForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
-    MPLogAdEvent([MPLogEvent adShowSuccessForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
-    MPLogAdEvent([MPLogEvent adDidAppearForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
-}
-
-- (void)didClickInterstitial:(CBLocation)location
-{
-    MPLogInfo(@"Chartboost interstitial was clicked. Location: %@", location);
+    if (error) {
+        NSError *nserror = [NSError errorWithClickEvent:event error:error];
+        MPLogAdEvent([MPLogEvent error:nserror message:nil], event.ad.location);
+    }
+    MPLogAdEvent([MPLogEvent adTappedForAdapter:NSStringFromClass(self.class)], event.ad.location);
     [self.delegate interstitialCustomEventDidReceiveTapEvent:self];
-    
-    MPLogAdEvent([MPLogEvent adTappedForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
 }
 
-- (NSString *) getAdNetworkId {
-    return appId;
+- (void)didDismissAd:(CHBDismissEvent *)event
+{
+    MPLogAdEvent([MPLogEvent adWillDisappearForAdapter:NSStringFromClass(self.class)], event.ad.location);
+    [self.delegate interstitialCustomEventWillDisappear:self];
+    MPLogAdEvent([MPLogEvent adDidDisappearForAdapter:NSStringFromClass(self.class)], event.ad.location);
+    [self.delegate interstitialCustomEventDidDisappear:self];
 }
 
 @end

--- a/Chartboost/ChartboostRewardedVideoCustomEvent.h
+++ b/Chartboost/ChartboostRewardedVideoCustomEvent.h
@@ -14,10 +14,4 @@
 #endif
 
 @interface ChartboostRewardedVideoCustomEvent : MPRewardedVideoCustomEvent
-
-/**
- * A string that corresponds to a Chartboost CBLocation used for differentiating ad requests.
- */
-@property (nonatomic, copy) NSString *location;
-
 @end

--- a/Chartboost/ChartboostRewardedVideoCustomEvent.m
+++ b/Chartboost/ChartboostRewardedVideoCustomEvent.m
@@ -6,131 +6,115 @@
 //
 
 #import "ChartboostRewardedVideoCustomEvent.h"
-#import "ChartboostAdapterConfiguration.h"
 #import "ChartboostRouter.h"
-#if __has_include("MoPub.h")
-    #import "MPLogging.h"
-    #import "MPRewardedVideoReward.h"
-    #import "MPRewardedVideoError.h"
-#endif
-#import <Chartboost/Chartboost.h>
+#import "NSError+ChartboostErrors.h"
 
-@interface ChartboostRewardedVideoCustomEvent () <ChartboostDelegate>
-@property (nonatomic, copy) NSString *appId;
+@interface ChartboostRewardedVideoCustomEvent () <CHBRewardedDelegate>
+@property (nonatomic) CHBRewarded *ad;
 @end
 
 @implementation ChartboostRewardedVideoCustomEvent
 
 - (void)requestRewardedVideoWithCustomEventInfo:(NSDictionary *)info adMarkup:(NSString *)adMarkup
 {
-    self.appId = [info objectForKey:@"appId"];
-
-    NSString *appSignature = [info objectForKey:@"appSignature"];
-
     NSString *location = [info objectForKey:@"location"];
-    self.location = [location length] != 0 ? location : CBLocationDefault;
+    location = location.length > 0 ? location : CBLocationDefault;
 
-    // Cache the network SDK initialization parameters
-    [ChartboostAdapterConfiguration updateInitializationParameters:info];
-
-    [[ChartboostRouter sharedRouter] cacheRewardedAdWithAppId:self.appId appSignature:appSignature location:self.location forChartboostRewardedVideoCustomEvent:self];
+    MPLogAdEvent([MPLogEvent adLoadAttemptForAdapter:NSStringFromClass(self.class) dspCreativeId:nil dspName:nil], location);
+    if (self.ad) {
+        MPLogAdEvent([MPLogEvent error:[NSError adRequestCalledTwiceOnSameEvent] message:nil], location);
+    }
+    
+    __weak typeof(self) weakSelf = self;
+    [ChartboostRouter startWithParameters:info completion:^(BOOL initialized) {
+        if (!initialized) {
+            NSError *error = [NSError adRequestFailedDueToSDKStartWithAdOfType:@"rewarded"];
+            MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:error], location);
+            [self.delegate rewardedVideoDidFailToLoadAdForCustomEvent:self error:error];
+            return;
+        }
+        
+        weakSelf.ad.delegate = nil;
+        weakSelf.ad = [[CHBRewarded alloc] initWithLocation:location mediation:[ChartboostRouter mediation] delegate:weakSelf];
+        [weakSelf.ad cache];
+    }];
 }
 
 - (void)presentRewardedVideoFromViewController:(UIViewController *)viewController
 {
-    MPLogAdEvent([MPLogEvent adShowAttemptForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
-
-    if ([[ChartboostRouter sharedRouter] hasCachedRewardedVideoForLocation:self.location]) {
-        [[ChartboostRouter sharedRouter] showRewardedVideoForLocation:self.location];
-    } else {
-        NSError *error = [NSError errorWithDomain:MoPubRewardedVideoAdsSDKDomain code:MPRewardedVideoAdErrorNoAdsAvailable userInfo:nil];
-        [self.delegate rewardedVideoDidFailToPlayForCustomEvent:self error:error];
-        MPLogAdEvent([MPLogEvent adShowFailedForAdapter:NSStringFromClass(self.class) error:error], [self getAdNetworkId]);
-    }
-}
-
-- (void)handleCustomEventInvalidated
-{
-    [[[ChartboostRouter sharedRouter] rewardedVideoEvents] removeObjectForKey:self.location];
+    MPLogAdEvent([MPLogEvent adShowAttemptForAdapter:NSStringFromClass(self.class)], self.ad.location);
+    [self.ad showFromViewController:viewController];
 }
 
 - (BOOL)hasAdAvailable
 {
-    return [[ChartboostRouter sharedRouter] hasCachedRewardedVideoForLocation:self.location];
+    return self.ad.isCached;
 }
 
-- (void)handleAdPlayedForCustomEventNetwork
+#pragma mark - CHBRewardedDelegate
+
+- (void)didCacheAd:(CHBCacheEvent *)event error:(CHBCacheError *)error
 {
-    // If we no longer have an ad available, report back up to the application that this ad expired.
-    // We receive this message only when this ad has reported an ad has loaded and another ad unit
-    // has played a video for the same ad network.
-    if (![self hasAdAvailable]) {
-        [self.delegate rewardedVideoDidExpireForCustomEvent:self];
+    if (error) {
+        NSError *nserror = [NSError errorWithCacheEvent:event error:error];
+        MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:nserror], event.ad.location);
+        NSError *mopubError = [NSError errorWithDomain:MoPubRewardedVideoAdsSDKDomain code:MPRewardedVideoAdErrorNoAdsAvailable userInfo:nil];
+        [self.delegate rewardedVideoDidFailToLoadAdForCustomEvent:self error:mopubError];
+    } else {
+        MPLogAdEvent([MPLogEvent adLoadSuccessForAdapter:NSStringFromClass(self.class)], event.ad.location);
+        [self.delegate rewardedVideoDidLoadAdForCustomEvent:self];
     }
 }
 
-#pragma mark - ChartboostDelegate methods
-
-- (void)didDisplayRewardedVideo:(CBLocation)location
+- (void)willShowAd:(CHBShowEvent *)event error:(CHBShowError *)error
 {
-    [self.delegate rewardedVideoWillAppearForCustomEvent:self];
-    [self.delegate rewardedVideoDidAppearForCustomEvent:self];
-    
-    MPLogAdEvent([MPLogEvent adWillAppearForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
-    MPLogAdEvent([MPLogEvent adShowSuccessForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
-    MPLogAdEvent([MPLogEvent adDidAppearForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
+    if (error) {
+        NSError *nserror = [NSError errorWithShowEvent:event error:error];
+        MPLogAdEvent([MPLogEvent adShowFailedForAdapter:NSStringFromClass(self.class) error:nserror], event.ad.location);
+        [self.delegate rewardedVideoDidFailToPlayForCustomEvent:self error:nserror];
+    } else {
+        MPLogAdEvent([MPLogEvent adWillAppearForAdapter:NSStringFromClass(self.class)], event.ad.location);
+        [self.delegate rewardedVideoWillAppearForCustomEvent:self];
+    }
 }
 
-- (void)didCacheRewardedVideo:(CBLocation)location
+- (void)didShowAd:(CHBShowEvent *)event error:(CHBShowError *)error
 {
-    [self.delegate rewardedVideoDidLoadAdForCustomEvent:self];
-    
-    MPLogAdEvent([MPLogEvent adLoadSuccessForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
+    if (error) {
+        NSError *nserror = [NSError errorWithShowEvent:event error:error];
+        MPLogAdEvent([MPLogEvent adShowFailedForAdapter:NSStringFromClass(self.class) error:nserror], self.ad.location);
+        NSError *mopubError = [NSError errorWithDomain:MoPubRewardedVideoAdsSDKDomain code:MPRewardedVideoAdErrorNoAdsAvailable userInfo:nil];
+        [self.delegate rewardedVideoDidFailToPlayForCustomEvent:self error:mopubError];
+    } else {
+        MPLogAdEvent([MPLogEvent adShowSuccessForAdapter:NSStringFromClass(self.class)], event.ad.location);
+        MPLogAdEvent([MPLogEvent adDidAppearForAdapter:NSStringFromClass(self.class)], event.ad.location);
+        [self.delegate rewardedVideoDidAppearForCustomEvent:self];
+    }
 }
 
-- (void)didFailToLoadRewardedVideo:(CBLocation)location
-                         withError:(CBLoadError)error
+- (void)didClickAd:(CHBClickEvent *)event error:(CHBClickError *)error
 {
-    
-    NSError *mopubError = [NSError errorWithDomain:MoPubRewardedVideoAdsSDKDomain code:MPRewardedVideoAdErrorNoAdsAvailable userInfo:nil];
-
-    [self.delegate rewardedVideoDidFailToLoadAdForCustomEvent:self error:mopubError];
-    MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:mopubError], [self getAdNetworkId]);
-}
-
-- (void)didDismissRewardedVideo:(CBLocation)location
-{
-    [self.delegate rewardedVideoWillDisappearForCustomEvent:self];
-    MPLogAdEvent([MPLogEvent adWillDisappearForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
-
-    [self.delegate rewardedVideoDidDisappearForCustomEvent:self];
-    MPLogAdEvent([MPLogEvent adDidDisappearForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
-}
-
-- (void)didCloseRewardedVideo:(CBLocation)location
-{
-    [self.delegate rewardedVideoWillDisappearForCustomEvent:self];
-    MPLogAdEvent([MPLogEvent adWillDisappearForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
-
-    [self.delegate rewardedVideoDidDisappearForCustomEvent:self];
-    MPLogAdEvent([MPLogEvent adDidDisappearForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
-}
-
-- (void)didClickRewardedVideo:(CBLocation)location
-{
+    if (error) {
+        NSError *nserror = [NSError errorWithClickEvent:event error:error];
+        MPLogAdEvent([MPLogEvent error:nserror message:nil], event.ad.location);
+    }
+    MPLogAdEvent([MPLogEvent adTappedForAdapter:NSStringFromClass(self.class)], event.ad.location);
     [self.delegate rewardedVideoDidReceiveTapEventForCustomEvent:self];
-    
-    MPLogAdEvent([MPLogEvent adTappedForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
 }
 
-- (void)didCompleteRewardedVideo:(CBLocation)location
-                      withReward:(int)reward
+- (void)didDismissAd:(CHBDismissEvent *)event
 {
-    [self.delegate rewardedVideoShouldRewardUserForCustomEvent:self reward:[[MPRewardedVideoReward alloc] initWithCurrencyAmount:@(reward)]];
+    MPLogAdEvent([MPLogEvent adWillDisappearForAdapter:NSStringFromClass(self.class)], event.ad.location);
+    [self.delegate rewardedVideoWillDisappearForCustomEvent:self];
+    MPLogAdEvent([MPLogEvent adDidDisappearForAdapter:NSStringFromClass(self.class)], event.ad.location);
+    [self.delegate rewardedVideoDidDisappearForCustomEvent:self];
 }
 
-- (NSString *) getAdNetworkId {
-    return self.appId;
+- (void)didEarnReward:(CHBRewardEvent *)event
+{
+    MPRewardedVideoReward *reward = [[MPRewardedVideoReward alloc] initWithCurrencyAmount:@(event.reward)];
+    MPLogAdEvent([MPLogEvent adShouldRewardUserWithReward:reward], event.ad.location);
+    [self.delegate rewardedVideoShouldRewardUserForCustomEvent:self reward:reward];
 }
 
 @end

--- a/Chartboost/ChartboostRewardedVideoCustomEvent.m
+++ b/Chartboost/ChartboostRewardedVideoCustomEvent.m
@@ -66,16 +66,10 @@
     }
 }
 
-- (void)willShowAd:(CHBShowEvent *)event error:(CHBShowError *)error
+- (void)willShowAd:(CHBShowEvent *)event
 {
-    if (error) {
-        NSError *nserror = [NSError errorWithShowEvent:event error:error];
-        MPLogAdEvent([MPLogEvent adShowFailedForAdapter:NSStringFromClass(self.class) error:nserror], event.ad.location);
-        [self.delegate rewardedVideoDidFailToPlayForCustomEvent:self error:nserror];
-    } else {
-        MPLogAdEvent([MPLogEvent adWillAppearForAdapter:NSStringFromClass(self.class)], event.ad.location);
-        [self.delegate rewardedVideoWillAppearForCustomEvent:self];
-    }
+    MPLogAdEvent([MPLogEvent adWillAppearForAdapter:NSStringFromClass(self.class)], event.ad.location);
+    [self.delegate rewardedVideoWillAppearForCustomEvent:self];
 }
 
 - (void)didShowAd:(CHBShowEvent *)event error:(CHBShowError *)error

--- a/Chartboost/ChartboostRouter.h
+++ b/Chartboost/ChartboostRouter.h
@@ -5,42 +5,23 @@
 //  Copyright (c) 2015 MoPub. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
 #import <Foundation/Foundation.h>
-#import <Chartboost/Chartboost.h>
+#if __has_include("MoPub.h")
+#import "MPLogging.h"
+#endif
+#if __has_include(<Chartboost/Chartboost+Mediation.h>)
+#import <Chartboost/Chartboost+Mediation.h>
+#else
+#import "Chartboost+Mediation.h"
+#endif
 
-@class ChartboostInterstitialCustomEvent;
-@class ChartboostRewardedVideoCustomEvent;
+NS_ASSUME_NONNULL_BEGIN
 
-/*
- * Maps all Chartboost locations for both interstitial and rewarded video ads to their
- * corresponding custom event objects. Also acts as primary Chartboost delegate and distributes
- * callbacks to their appropriate custom events.
- */
-@interface ChartboostRouter : NSObject <ChartboostDelegate>
-
-@property (nonatomic, strong) NSMutableDictionary *interstitialEvents;
-@property (nonatomic, strong) NSMutableSet *activeInterstitialLocations;
-@property (nonatomic, strong) NSMutableDictionary *rewardedVideoEvents;
-
-+ (ChartboostRouter *)sharedRouter;
-- (void)startWithAppId:(NSString *)appId appSignature:(NSString *)appSignature completion:(void(^)(BOOL))completion;
-
-/*
- * Interstitial Ads
- */
-- (void)cacheInterstitialWithAppId:(NSString *)appId appSignature:(NSString *)appSignature location:(NSString *)location forChartboostInterstitialCustomEvent:(ChartboostInterstitialCustomEvent *)event;
-- (BOOL)hasCachedInterstitialForLocation:(NSString *)location;
-- (void)showInterstitialForLocation:(NSString *)location;
-- (void)unregisterInterstitialEvent:(ChartboostInterstitialCustomEvent *)event;
-
-/*
- * Rewarded Video Ads
- */
-
-- (void)cacheRewardedAdWithAppId:(NSString *)appId appSignature:(NSString *)appSignature location:(NSString *)location forChartboostRewardedVideoCustomEvent:(ChartboostRewardedVideoCustomEvent *)event;
-- (BOOL)hasCachedRewardedVideoForLocation:(NSString *)location;
-- (void)showRewardedVideoForLocation:(NSString *)location;
-
-
+@interface ChartboostRouter : NSObject
++ (CHBMediation *)mediation;
++ (void)setLoggingLevel:(MPBLogLevel)loggingLevel;
++ (void)setDataUseConsentWithMopubConfiguration;
++ (void)startWithParameters:(NSDictionary *)parameters completion:(void(^)(BOOL))completion;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Chartboost/ChartboostRouter.m
+++ b/Chartboost/ChartboostRouter.m
@@ -10,333 +10,74 @@
     #import "MPLogging.h"
     #import "MoPub.h"
 #endif
-#import "ChartboostRewardedVideoCustomEvent.h"
-#import "ChartboostInterstitialCustomEvent.h"
 #import "ChartboostAdapterConfiguration.h"
 
-@interface ChartboostRewardedVideoCustomEvent (ChartboostRouter) <ChartboostDelegate>
-@end
-
-@interface ChartboostInterstitialCustomEvent (ChartboostRouter) <ChartboostDelegate>
-@end
-
-/*
- * Chartboost only provides a shared instance, so only one object may be the Chartboost delegate at
- * any given time. However, because it is common to request Chartboost interstitials for separate
- * "locations" in a single app session, we may have multiple instances of our custom event class,
- * all of which are interested in delegate callbacks.
- *
- * ChartboostRouter is a singleton that is always the Chartboost delegate, and dispatches
- * events to all of the custom event instances.
- */
-
-typedef void(^InitializationCompletion)(BOOL);
-typedef NS_ENUM(NSUInteger, InitializationState) {
-    InitializationStateNotStarted,
-    InitializationStateOngoing,
-    InitializationStateSucceeded,
-    InitializationStateFailed
-};
-
-@interface ChartboostRouter ()
-@property (nonatomic) NSMutableArray<InitializationCompletion> *initializationCompletions;
-@property (nonatomic) InitializationState initialized;
-@end
+static NSString * const kChartboostAppIdKey        = @"appId";
+static NSString * const kChartboostAppSignatureKey = @"appSignature";
 
 @implementation ChartboostRouter
 
-+ (ChartboostRouter *)sharedRouter
++ (CHBMediation *)mediation
 {
-    static ChartboostRouter * sharedRouter;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        sharedRouter = [[ChartboostRouter alloc] init];
-    });
-    return sharedRouter;
+    return [[CHBMediation alloc] initWithType:CBMediationMoPub
+                               libraryVersion:MP_SDK_VERSION
+                               adapterVersion:[ChartboostAdapterConfiguration adapterVersion]];
 }
 
-- (id)init
++ (void)setLoggingLevel:(MPBLogLevel)loggingLevel
 {
-    
-    self = [super init];
-    if (self) {
-        self.interstitialEvents = [NSMutableDictionary dictionary];
-        self.rewardedVideoEvents = [NSMutableDictionary dictionary];
-        self.initializationCompletions = [NSMutableArray array];
-        self.initialized = InitializationStateNotStarted;
-        
-        /*
-         * We need the active locations set to keep track of locations that are currently being
-         * cached/ready to show/visible on screen for interstitial ads.
-         * It is *not* enough to just use the events dictionary.  The reason is that when a user
-         * taps a Chartboost interstitial.  Chartboost calls didDismissInterstitial *before* it calls
-         * didClickInterstitial.  Since we *must* mark the location as available for reuse when
-         * the interstitial is dismissed (e.g. the user simply closes it) the only way to allow
-         * for click tracking, is to ensure that the event is still available after dismissal, but
-         * is marked as free to be released.
-         */
-        
-        // Collect and pass the user's consent from MoPub onto the Chartboost SDK
-        if ([[MoPub sharedInstance] isGDPRApplicable] == MPBoolYes){
-            if ([[MoPub sharedInstance] allowLegitimateInterest] == YES){
-                if ([[MoPub sharedInstance] currentConsentStatus] == MPConsentStatusDenied
-                    || [[MoPub sharedInstance] currentConsentStatus] == MPConsentStatusDoNotTrack) {
-                    
-                    [Chartboost setPIDataUseConsent:NoBehavioral];
-                }
-                else {
-                    [Chartboost setPIDataUseConsent:YesBehavioral];
-                }
+    CBLoggingLevel chbLoggingLevel = [self chartboostLoggingLevelFromMopubLevel:loggingLevel];
+    [Chartboost setLoggingLevel:chbLoggingLevel];
+}
+
++ (CBLoggingLevel)chartboostLoggingLevelFromMopubLevel:(MPBLogLevel)logLevel
+{
+    switch (logLevel) {
+        case MPBLogLevelDebug:
+            return CBLoggingLevelVerbose;
+        case MPBLogLevelInfo:
+            return CBLoggingLevelInfo;
+        case MPBLogLevelNone:
+            return CBLoggingLevelOff;
+    }
+    return CBLoggingLevelOff;
+}
+
++ (void)setDataUseConsentWithMopubConfiguration
+{
+    MoPub *mopub = [MoPub sharedInstance];
+    if ([mopub isGDPRApplicable] == MPBoolYes) {
+        if ([mopub allowLegitimateInterest]) {
+            if ([mopub currentConsentStatus] == MPConsentStatusDenied || [mopub currentConsentStatus] == MPConsentStatusDoNotTrack) {
+                [Chartboost setPIDataUseConsent:NoBehavioral];
             } else {
-                if ([[MoPub sharedInstance] canCollectPersonalInfo] == YES) {
-                    [Chartboost setPIDataUseConsent:YesBehavioral];
-                }
-                else {
-                    [Chartboost setPIDataUseConsent:NoBehavioral];
-                }
+                [Chartboost setPIDataUseConsent:YesBehavioral];
+            }
+        } else {
+            if ([mopub canCollectPersonalInfo]) {
+                [Chartboost setPIDataUseConsent:YesBehavioral];
+            } else {
+                [Chartboost setPIDataUseConsent:NoBehavioral];
             }
         }
-        
-        self.activeInterstitialLocations = [NSMutableSet set];
-    }
-    return self;
-}
-
-- (void)startWithAppId:(NSString *)appId appSignature:(NSString *)appSignature completion:(void(^)(BOOL))completion
-{
-    @synchronized (self) {
-        switch (self.initialized) {
-            case InitializationStateNotStarted:
-            case InitializationStateFailed:
-                if (completion) {
-                    [self.initializationCompletions addObject:completion];
-                }
-                [self startWithAppId:appId appSignature:appSignature];
-                break;
-            case InitializationStateOngoing:
-                if (completion) {
-                    [self.initializationCompletions addObject:completion];
-                }
-                break;
-            case InitializationStateSucceeded:
-                if (completion) {
-                    completion(YES);
-                }
-                break;
-        }
     }
 }
 
-- (void)startWithAppId:(NSString *)appId appSignature:(NSString *)appSignature
++ (void)startWithParameters:(NSDictionary *)parameters completion:(void (^)(BOOL))completion
 {
-    @synchronized (self) {
-        if (self.initialized == InitializationStateOngoing || self.initialized == InitializationStateSucceeded) {
-            return;
-        }
-        self.initialized = InitializationStateOngoing;
-        [Chartboost startWithAppId:appId appSignature:appSignature delegate:self];
-        [Chartboost setMediation:CBMediationMoPub withLibraryVersion:MP_SDK_VERSION adapterVersion:[ChartboostAdapterConfiguration mediationString]];
-        [Chartboost setAutoCacheAds:FALSE];
-    }
-}
-
-#pragma mark - Insterstitial Ads
-
-- (void)cacheInterstitialWithAppId:(NSString *)appId appSignature:(NSString *)appSignature location:(NSString *)location forChartboostInterstitialCustomEvent:(ChartboostInterstitialCustomEvent *)event
-{
-    if ([self.activeInterstitialLocations containsObject:location]) {
-        [event didFailToLoadInterstitial:location withError:CBLoadErrorInternal];
-        
-        NSError *error = [NSError errorWithCode:MOPUBErrorAdapterInvalid localizedDescription:@"Failed to load Chartboost interstitial: this location is already in use."];
-        MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:error], appId);
-        
+    NSString *appId = parameters[kChartboostAppIdKey];
+    NSString *appSignature = parameters[kChartboostAppSignatureKey];
+    
+    if (appId.length == 0 || appSignature.length == 0) {
+        NSError *error = [NSError errorWithCode:MOPUBErrorAdapterInvalid
+                           localizedDescription:@"Failed to initialize Chartboost SDK: missing appId or appSignature. Make sure you have a valid appId and appSignature entered on the MoPub dashboard."];
+        MPLogEvent([MPLogEvent error:error message:nil]);
+        completion(NO);
         return;
     }
     
-    if ([appId length] > 0 && [appSignature length] > 0) {
-        [self setInterstitialEvent:event forLocation:location];
-        
-        [self startWithAppId:appId appSignature:appSignature completion:nil];
-        
-        if ([self hasCachedInterstitialForLocation:location]) {
-            [self didCacheInterstitial:location];
-        } else {
-            [Chartboost cacheInterstitial:location];
-            
-            MPLogAdEvent([MPLogEvent adLoadAttemptForAdapter:NSStringFromClass(self.class) dspCreativeId:nil dspName:nil], appId);
-        }
-    } else {
-        [event didFailToLoadInterstitial:location withError:CBLoadErrorInternal];
-        
-        NSError *error = [NSError errorWithCode:MOPUBErrorAdapterInvalid localizedDescription:@"Failed to load Chartboost interstitial: missing either appId or appSignature."];
-        MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:error], appId);
-    }
-}
-
-- (BOOL)hasCachedInterstitialForLocation:(NSString *)location
-{
-    return [Chartboost hasInterstitial:location];
-}
-
-- (void)showInterstitialForLocation:(NSString *)location
-{
-    [Chartboost showInterstitial:location];
-}
-
-- (ChartboostInterstitialCustomEvent *)interstitialEventForLocation:(NSString *)location
-{
-    return [self.interstitialEvents objectForKey:location];
-}
-
-- (void)setInterstitialEvent:(ChartboostInterstitialCustomEvent *)event forLocation:(NSString *)location
-{
-    [self.interstitialEvents setObject:event forKey:location];
-    [self.activeInterstitialLocations addObject:location];
-}
-
-- (void)unregisterInterstitialEventForLocation:(NSString *)location
-{
-    [self.activeInterstitialLocations removeObject:location];
-}
-
-- (void)unregisterInterstitialEvent:(ChartboostInterstitialCustomEvent *)event
-{
-    if ([[self.interstitialEvents objectForKey:event.location] isEqual:event]) {
-        [self unregisterInterstitialEventForLocation:event.location];
-    }
-}
-
-#pragma mark - Rewarded Video Ads
-
-- (void)cacheRewardedAdWithAppId:(NSString *)appId appSignature:(NSString *)appSignature location:(NSString *)location forChartboostRewardedVideoCustomEvent:(ChartboostRewardedVideoCustomEvent *)event
-{
-    if ([appId length] > 0 && [appSignature length] > 0) {
-        [self setRewardedVideoEvent:event forLocation:location];
-        
-        [self startWithAppId:appId appSignature:appSignature completion:nil];
-        
-        if ([self hasCachedRewardedVideoForLocation:location]) {
-            [self didCacheRewardedVideo:location];
-        } else {
-            [Chartboost cacheRewardedVideo:location];
-            
-            MPLogAdEvent([MPLogEvent adLoadAttemptForAdapter:NSStringFromClass(self.class) dspCreativeId:nil dspName:nil], appId);
-        }
-    } else {
-        [event didFailToLoadRewardedVideo:location withError:CBLoadErrorInternal];
-        
-        NSError *error = [NSError errorWithCode:MOPUBErrorAdapterInvalid localizedDescription:@"Failed to load Chartboost rewarded video: missing either appId or appSignature"];
-        MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:error], appId);
-    }
-}
-
-- (BOOL)hasCachedRewardedVideoForLocation:(NSString *)location
-{
-    return [Chartboost hasRewardedVideo:location];
-}
-
-- (void)showRewardedVideoForLocation:(NSString *)location
-{
-    if ([self hasCachedRewardedVideoForLocation:location]) {
-        [Chartboost showRewardedVideo:location];
-    }
-}
-
-- (ChartboostRewardedVideoCustomEvent *)rewardedVideoEventForLocation:(NSString *)location
-{
-    return [self.rewardedVideoEvents objectForKey:location];
-}
-
-- (void)setRewardedVideoEvent:(ChartboostRewardedVideoCustomEvent *)event forLocation:(NSString *)location
-{
-    [self.rewardedVideoEvents setObject:event forKey:location];
-}
-
-#pragma mark - ChartboostDelegate common methods
-
-- (void)didInitialize:(BOOL)status
-{
-    @synchronized (self) {
-        self.initialized = status ? InitializationStateSucceeded : InitializationStateFailed;
-        for (InitializationCompletion completion in self.initializationCompletions) {
-            completion(status);
-        }
-        [self.initializationCompletions removeAllObjects];
-    }
-}
-
-#pragma mark - ChartboostDelegate Interstitial methods
-
-- (void)didCacheInterstitial:(NSString *)location
-{
-    [[self interstitialEventForLocation:location] didCacheInterstitial:location];
-}
-
-- (void)didFailToLoadInterstitial:(NSString *)location withError:(CBLoadError)error
-{
-    [[self interstitialEventForLocation:location] didFailToLoadInterstitial:location withError:CBLoadErrorInternal];
-    [self unregisterInterstitialEventForLocation:location];
-}
-
-- (void)didDisplayInterstitial:(NSString *)location
-{
-    [[self interstitialEventForLocation:location] didDisplayInterstitial:location];
-}
-
-- (void)didDismissInterstitial:(NSString *)location
-{
-    [[self interstitialEventForLocation:location] didDismissInterstitial:location];
-    [self unregisterInterstitialEventForLocation:location];
-}
-
-- (void)didClickInterstitial:(NSString *)location
-{
-    [[self interstitialEventForLocation:location] didClickInterstitial:location];
-}
-
-#pragma mark - ChartboostDelegate Rewarded Video methods
-
-- (BOOL)shouldDisplayRewardedVideo:(CBLocation)location
-{
-    return YES;
-}
-
-- (void)didDisplayRewardedVideo:(CBLocation)location
-{
-    [[self rewardedVideoEventForLocation:location] didDisplayRewardedVideo:location];
-}
-
-- (void)didCacheRewardedVideo:(CBLocation)location
-{
-    [[self rewardedVideoEventForLocation:location] didCacheRewardedVideo:location];
-}
-
-- (void)didFailToLoadRewardedVideo:(CBLocation)location withError:(CBLoadError)error
-{
-    [[self rewardedVideoEventForLocation:location] didFailToLoadRewardedVideo:location withError:CBLoadErrorInternal];
-}
-
-- (void)didDismissRewardedVideo:(CBLocation)location
-{
-    [[self rewardedVideoEventForLocation:location] didDismissRewardedVideo:location];
-    [self.rewardedVideoEvents removeObjectForKey:location];
-    [Chartboost cacheRewardedVideo:location];
-}
-
-- (void)didCloseRewardedVideo:(CBLocation)location
-{
-    [[self rewardedVideoEventForLocation:location] didCloseRewardedVideo:location];
-    [self.rewardedVideoEvents removeObjectForKey:location];
-}
-
-- (void)didClickRewardedVideo:(CBLocation)location
-{
-    [[self rewardedVideoEventForLocation:location] didClickRewardedVideo:location];
-}
-
-- (void)didCompleteRewardedVideo:(CBLocation)location withReward:(int)reward
-{
-    [[self rewardedVideoEventForLocation:location] didCompleteRewardedVideo:location withReward:reward];
+    [ChartboostAdapterConfiguration updateInitializationParameters:parameters];
+    [Chartboost startWithAppId:appId appSignature:appSignature completion:completion];
 }
 
 @end

--- a/Chartboost/NSError+ChartboostErrors.h
+++ b/Chartboost/NSError+ChartboostErrors.h
@@ -1,0 +1,26 @@
+//
+//  NSError+ChartboostErrors.h
+//  MoPubSDK
+//
+//  Copyright © 2019 Chartboost. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#if __has_include(<Chartboost/Chartboost+Mediation.h>)
+#import <Chartboost/Chartboost+Mediation.h>
+#else
+#import "Chartboost+Mediation.h"
+#endif
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSError (ChartboostErrors)
++ (NSError *)errorWithCacheEvent:(CHBCacheEvent *)event error:(CHBCacheError *)error;
++ (NSError *)errorWithShowEvent:(CHBShowEvent *)event error:(CHBShowError *)error;
++ (NSError *)errorWithClickEvent:(CHBClickEvent *)event error:(CHBClickError *)error;
++ (NSError *)errorWithDidFinishHandlingClickEvent:(CHBClickEvent *)event error:(CHBClickError *)error;
++ (NSError *)adRequestCalledTwiceOnSameEvent;
++ (NSError *)adRequestFailedDueToSDKStartWithAdOfType:(NSString *)adType;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Chartboost/NSError+ChartboostErrors.m
+++ b/Chartboost/NSError+ChartboostErrors.m
@@ -1,0 +1,70 @@
+//
+//  NSError+ChartboostErrors.m
+//  MoPubSDK
+//
+//  Copyright © 2019 Chartboost. All rights reserved.
+//
+
+#import "NSError+ChartboostErrors.h"
+
+#if __has_include(<MoPub/MoPub.h>)
+#import <MoPub/MoPub.h>
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+#import <MoPubSDKFramework/MoPub.h>
+#else
+#import "MPError.h"
+#endif
+
+
+@implementation NSError (ChartboostErrors)
+
++ (NSError *)errorWithCacheEvent:(CHBCacheEvent *)event error:(CHBCacheError *)error
+{
+    return [NSError errorWithCode:MOPUBErrorAdapterFailedToLoadAd
+             localizedDescription:[NSString stringWithFormat:@"Chartboost adapter failed to load %@ with location %@ and error %@", [self adTypeNameForAd:event.ad], event.ad.location, error.description]];
+}
+
++ (NSError *)errorWithShowEvent:(CHBShowEvent *)event error:(CHBShowError *)error
+{
+    return [NSError errorWithCode:MOPUBErrorAdapterFailedToLoadAd
+             localizedDescription:[NSString stringWithFormat:@"Chartboost adapter failed to show %@ with location %@ and error %@", [self adTypeNameForAd:event.ad], event.ad.location, error.description]];
+}
+
++ (NSError *)errorWithClickEvent:(CHBClickEvent *)event error:(CHBClickError *)error
+{
+    return [NSError errorWithCode:MOPUBErrorUnknown
+             localizedDescription:[NSString stringWithFormat:@"Chartboost adapter failed to click %@ with location %@ and error %@", [self adTypeNameForAd:event.ad], event.ad.location, error.description]];
+}
+
++ (NSError *)errorWithDidFinishHandlingClickEvent:(CHBClickEvent *)event error:(CHBClickError *)error
+{
+    return [NSError errorWithCode:MOPUBErrorUnknown
+             localizedDescription:[NSString stringWithFormat:@"Chartboost adapter did finish handling click for %@ with location %@ and error %@", [self adTypeNameForAd:event.ad], event.ad.location, error.description]];
+}
+
++ (NSError *)adRequestCalledTwiceOnSameEvent
+{
+    return [NSError errorWithCode:MOPUBErrorUnknown
+             localizedDescription:@"Chartboost adapter error: requestAdWithSize called twice on the same event."];
+}
+
++ (NSError *)adRequestFailedDueToSDKStartWithAdOfType:(NSString *)adType
+{
+    return [NSError errorWithCode:MOPUBErrorAdapterInvalid
+             localizedDescription:[NSString stringWithFormat:@"Failed to load Chartboost %@: sdk initialization failed.", adType]];
+}
+
++ (NSString *)adTypeNameForAd:(id<CHBAd>)ad
+{
+    if ([ad isKindOfClass:CHBInterstitial.class]) {
+        return @"interstitial";
+    } else if ([ad isKindOfClass:CHBRewarded.class]) {
+        return @"rewarded";
+    } else if ([ad isKindOfClass:CHBBanner.class]) {
+        return @"banner";
+    } else {
+        return @"ad";
+    }
+}
+
+@end


### PR DESCRIPTION
Rewrote most of the adapters to support Chartboost new ad types.

Instead of interacting with ads trough the Chartboost singleton now we use ad instances that are independent from each other. This required huge changes in the adapters.

The main changes are:
- **ChartboostAdapterConfiguration**:
  - minor cleanup
  - moved chartboost logic to ChartboostRouter and passed the whole config dictionary in the start function.
- **ChartboostBannerCustomEvent**:
  - removed duplicate code related to sdk initialization (everything related to initialization and credentials now lives in ChartboostRouter)
  - moved error mapping helpers to a new file (they are shared with the new interstitial and rewarded custom event classes)
  - substituted deprecated `willShow:error:` delegate method
- **ChartboostInterstitialCustomEvent**:
  - removed code related to sdk initialization
  - using CHBInterstitial class to interact with Chartboost interstitials instead of using the Chartboost singleton (through ChartboostRouter) for this.
  - you'll see the new implementation is very similar to the `ChartboostBannerCustomEvent` one.
- **ChartboostRewardedVideoCustomEvent**:
  - removed code related to sdk initialization
  - using CHBRewarded class to interact with Chartboost rewarded ads instead of using the Chartboost singleton (through ChartboostRouter) for this.
- **ChartboostRouter**:
  - Removed any ad related code (everything is now handled by the custom event classes)
  - Moved logging level mapping code here.
  - Refactored data use consent mapping code into its own function.
  - Using new method +[Chartboost startWithAppId:appSignature:completion], which can be called many times and takes a completion block instead of a delegate, greatly simplifying the initialization code.
- **NSError+ChartboostErrors**:
  - New file with error mapping logic used by all the ad custom event classes.

Please let me know of any doubt or concern.