### PR TITLE
Release Vungle adapter 6.5.3.0

### DIFF
--- a/Vungle/CHANGELOG.md
+++ b/Vungle/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Changelog
+* 6.5.3.0
+   * This version of the adapters has been certified with Vungle 6.5.3.
+
 * 6.5.2.0
    * This version of the adapters has been certified with Vungle 6.5.2.
    * Add support for Vungle's newly-introduced banner format.

--- a/Vungle/CHANGELOG.md
+++ b/Vungle/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 * 6.5.3.0
-   * This version of the adapters has been certified with Vungle 6.5.3.
+   * This version of the adapters has been certified with Vungle 6.5.3 and MoPub SDK 5.11.0.
 
 * 6.5.2.0
    * This version of the adapters has been certified with Vungle 6.5.2.

--- a/Vungle/VungleAdapterConfiguration.m
+++ b/Vungle/VungleAdapterConfiguration.m
@@ -41,7 +41,7 @@ typedef NS_ENUM(NSInteger, VungleAdapterErrorCode) {
 #pragma mark - MPAdapterConfiguration
 
 - (NSString *)adapterVersion {
-    return @"6.5.2.0";
+    return @"6.5.3.0";
 }
 
 - (NSString *)biddingToken {


### PR DESCRIPTION
Vungle iOS MoPub Adapter 6.5.3.0 Release

- This version of adapter is compatible with Vungle 6.5.3 SDK.