### PR TITLE
Chartboost 8.1.0.0 fixes

### DIFF
--- a/Chartboost/CHANGELOG.md
+++ b/Chartboost/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Changelog
+
+  * 8.1.0.1
+      * Fixes a bug that caused Chartboost initialization to fail and prevented data use consent to be set.
+
   * 8.1.0.0
       * This version of the adapters has been certified with Chartboost 8.1.0 and MoPub 5.11.0.
       * Add support for multiple Chartboost ad instances.

--- a/Chartboost/CHANGELOG.md
+++ b/Chartboost/CHANGELOG.md
@@ -2,6 +2,7 @@
 
   * 8.1.0.1
       * Fixes a bug that caused Chartboost initialization to fail and prevented data use consent to be set.
+      * Fixes compatibility with MoPub integrated both as source code and as binary framework.
 
   * 8.1.0.0
       * This version of the adapters has been certified with Chartboost 8.1.0 and MoPub 5.11.0.

--- a/Chartboost/ChartboostAdapterConfiguration.h
+++ b/Chartboost/ChartboostAdapterConfiguration.h
@@ -1,9 +1,9 @@
 #if __has_include(<MoPub/MoPub.h>)
-#import <MoPub/MoPub.h>
+    #import <MoPub/MoPub.h>
 #elif __has_include(<MoPubSDKFramework/MoPub.h>)
-#import <MoPubSDKFramework/MoPub.h>
+    #import <MoPubSDKFramework/MoPub.h>
 #else
-#import "MPBaseAdapterConfiguration.h"
+    #import "MPBaseAdapterConfiguration.h"
 #endif
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Chartboost/ChartboostAdapterConfiguration.m
+++ b/Chartboost/ChartboostAdapterConfiguration.m
@@ -1,8 +1,5 @@
 #import "ChartboostAdapterConfiguration.h"
 #import "ChartboostRouter.h"
-#if __has_include("MoPub.h")
-#import "MPLogging.h"
-#endif
 
 #define CHARTBOOST_ADAPTER_VERSION             @"8.1.0.0"
 #define MOPUB_NETWORK_NAME                     @"chartboost"

--- a/Chartboost/ChartboostAdapterConfiguration.m
+++ b/Chartboost/ChartboostAdapterConfiguration.m
@@ -1,7 +1,7 @@
 #import "ChartboostAdapterConfiguration.h"
 #import "ChartboostRouter.h"
 
-#define CHARTBOOST_ADAPTER_VERSION             @"8.1.0.0"
+#define CHARTBOOST_ADAPTER_VERSION             @"8.1.0.1"
 #define MOPUB_NETWORK_NAME                     @"chartboost"
 
 // Constants

--- a/Chartboost/ChartboostAdapterConfiguration.m
+++ b/Chartboost/ChartboostAdapterConfiguration.m
@@ -69,7 +69,6 @@ typedef NS_ENUM(NSInteger, ChartboostAdapterErrorCode) {
     }
     
     NSString * appSignature = configuration[kChartboostAppSignatureKey];
-    appSignature = @"";
     if (appSignature == nil || appSignature.length == 0) {
         NSError *error = [NSError errorWithDomain:kAdapterErrorDomain
                                              code:ChartboostAdapterErrorCodeMissingAppSignature

--- a/Chartboost/ChartboostBannerCustomEvent.h
+++ b/Chartboost/ChartboostBannerCustomEvent.h
@@ -11,7 +11,6 @@
     #import <MoPubSDKFramework/MoPub.h>
 #else
     #import "MPBannerCustomEvent.h"
-#import "MoPub.h"
 #endif
 
 @interface ChartboostBannerCustomEvent : MPBannerCustomEvent

--- a/Chartboost/ChartboostRewardedVideoCustomEvent.m
+++ b/Chartboost/ChartboostRewardedVideoCustomEvent.m
@@ -9,22 +9,6 @@
 #import "ChartboostRouter.h"
 #import "NSError+ChartboostErrors.h"
 
-#if __has_include(<MoPubSDKFramework/MoPub.h>)
-    #import <MoPubSDKFramework/MoPub.h>
-#else
-    #import "MoPub.h"
-#endif
-#if __has_include(<MoPubSDKFramework/MPLogging.h>)
-    #import <MoPubSDKFramework/MPLogging.h>
-#else
-    #import "MPLogging.h"
-#endif
-#if __has_include(<MoPubSDKFramework/MPRewardedVideoReward.h>)
-    #import <MoPubSDKFramework/MPRewardedVideoReward.h>
-#else
-    #import "MPRewardedVideoReward.h"
-#endif
-
 @interface ChartboostRewardedVideoCustomEvent () <CHBRewardedDelegate>
 @property (nonatomic) CHBRewarded *ad;
 @end

--- a/Chartboost/ChartboostRouter.h
+++ b/Chartboost/ChartboostRouter.h
@@ -6,13 +6,17 @@
 //
 
 #import <Foundation/Foundation.h>
-#if __has_include("MoPub.h")
-#import "MPLogging.h"
+#if __has_include(<MoPub/MoPub.h>)
+    #import <MoPub/MoPub.h>
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+    #import <MoPubSDKFramework/MoPub.h>
+#else
+    #import "MoPub.h"
 #endif
 #if __has_include(<Chartboost/Chartboost+Mediation.h>)
-#import <Chartboost/Chartboost+Mediation.h>
+    #import <Chartboost/Chartboost+Mediation.h>
 #else
-#import "Chartboost+Mediation.h"
+    #import "Chartboost+Mediation.h"
 #endif
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Chartboost/ChartboostRouter.m
+++ b/Chartboost/ChartboostRouter.m
@@ -6,10 +6,6 @@
 //
 
 #import "ChartboostRouter.h"
-#if __has_include("MoPub.h")
-    #import "MPLogging.h"
-    #import "MoPub.h"
-#endif
 #import "ChartboostAdapterConfiguration.h"
 
 static NSString * const kChartboostAppIdKey        = @"appId";


### PR DESCRIPTION
Found a bug in the latest adapters that prevents the initialization with stored config from ever succeeding (the appSignature was being always set to an empty string).
Also fixed imports to handle both the case where MoPub is integrated as source code ("MoPub.h" headers and similar) and where it is integrated as binary framework (<MoPub/MoPub.h> and similar).