### PR TITLE
Vungle iOS MoPub Adapter 6.6.1.0 release

### DIFF
--- a/Vungle/CHANGELOG.md
+++ b/Vungle/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Changelog
+* 6.6.1.0
+   * This version of the adapters has been certified with Vungle 6.6.1 and MoPub SDK 5.11.0.
+   * Add support for Header Bidding Participation.
+
 * 6.5.3.1
    * Fix `scheduledTimerWithTimeInterval` called for iOS 9.
 

--- a/Vungle/CHANGELOG.md
+++ b/Vungle/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 * 6.6.1.0
-   * This version of the adapters has been certified with Vungle 6.6.1 and MoPub SDK 5.11.0.
+   * This version of the adapters has been certified with Vungle 6.6.1 and MoPub SDK 5.12.1.
    * Add support for Header Bidding Participation.
 
 * 6.5.3.1

--- a/Vungle/VungleAdapterConfiguration.m
+++ b/Vungle/VungleAdapterConfiguration.m
@@ -45,7 +45,9 @@ typedef NS_ENUM(NSInteger, VungleAdapterErrorCode) {
 }
 
 - (NSString *)biddingToken {
-    return [[VungleRouter sharedRouter] currentSuperToken];
+    NSString *bidToken = [[VungleRouter sharedRouter] currentSuperToken];
+    MPLogInfo(@"Vungle: Get bidding token: %@.", bidToken);
+    return bidToken;
 }
 
 - (NSString *)moPubNetworkName {

--- a/Vungle/VungleAdapterConfiguration.m
+++ b/Vungle/VungleAdapterConfiguration.m
@@ -45,7 +45,7 @@ typedef NS_ENUM(NSInteger, VungleAdapterErrorCode) {
 }
 
 - (NSString *)biddingToken {
-    return nil;
+    return [[VungleRouter sharedRouter] currentSuperToken];
 }
 
 - (NSString *)moPubNetworkName {

--- a/Vungle/VungleAdapterConfiguration.m
+++ b/Vungle/VungleAdapterConfiguration.m
@@ -41,7 +41,7 @@ typedef NS_ENUM(NSInteger, VungleAdapterErrorCode) {
 #pragma mark - MPAdapterConfiguration
 
 - (NSString *)adapterVersion {
-    return @"6.5.3.1";
+    return @"6.6.1.0";
 }
 
 - (NSString *)biddingToken {

--- a/Vungle/VungleRouter.h
+++ b/Vungle/VungleRouter.h
@@ -40,6 +40,7 @@ extern const CGSize kVNGLeaderboardBannerSize;
 - (void)requestRewardedVideoAdWithCustomEventInfo:(NSDictionary *)info delegate:(id<VungleRouterDelegate>)delegate;
 - (void)requestBannerAdWithCustomEventInfo:(NSDictionary *)info size:(CGSize)size delegate:(id<VungleRouterDelegate>)delegate;
 - (BOOL)isAdAvailableForPlacementId:(NSString *)placementId;
+- (NSString *)currentSuperToken;
 - (void)presentInterstitialAdFromViewController:(UIViewController *)viewController options:(NSDictionary *)options forPlacementId:(NSString *)placementId;
 - (void)presentRewardedVideoAdFromViewController:(UIViewController *)viewController customerId:(NSString *)customerId settings:(VungleInstanceMediationSettings *)settings forPlacementId:(NSString *)placementId;
 - (UIView *)renderBannerAdInView:(UIView *)bannerView options:(NSDictionary *)options forPlacementID:(NSString *)placementID size:(CGSize)size;

--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -12,6 +12,7 @@
     #import "MPRewardedVideo.h"
     #import "MoPub.h"
 #endif
+#import <VungleSDK/VungleSDKHeaderBidding.h>
 #import "VungleInstanceMediationSettings.h"
 #import "VungleAdapterConfiguration.h"
 
@@ -313,6 +314,13 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
     }
 
     return [[VungleSDK sharedSDK] isAdCachedForPlacementID:placementId withSize:[self getVungleBannerAdSizeType:size]];
+}
+
+- (NSString *)currentSuperToken {
+    if (self.sdkInitializeState == SDKInitializeStateInitialized) {
+        return [[VungleSDK sharedSDK] currentSuperToken];
+    }
+    return nil;
 }
 
 - (void)presentInterstitialAdFromViewController:(UIViewController *)viewController options:(NSDictionary *)options forPlacementId:(NSString *)placementId {


### PR DESCRIPTION
This version of the adapters has been certified with Vungle 6.6.1 and MoPub SDK 5.11.0.
Add support for Header Bidding Participation.