### PR TITLE
IronSource SDK initialization improvements

### DIFF
--- a/IronSource/IronSourceInterstitialCustomEvent.m
+++ b/IronSource/IronSourceInterstitialCustomEvent.m
@@ -57,7 +57,7 @@
             MPLogInfo(@"IronSource Interstitial initialization with appkey %@", appKey);
             // Cache the initialization parameters
             [IronSourceAdapterConfiguration updateInitializationParameters:info];
-            [[IronSourceManager sharedManager] initIronSourceSDKWithAppKey:appKey forAdUnits:[NSSet setWithObject:@[IS_INTERSTITIAL]]];
+            [[IronSourceManager sharedManager] initIronSourceSDKWithAppKey:appKey forAdUnits:[NSSet setWithObject:IS_INTERSTITIAL]];
             [self loadInterstitial:self.instanceId];
         } else {
             MPLogInfo(@"IronSource Interstitial initialization with empty or nil appKey for instance @s",

--- a/IronSource/IronSourceManager.m
+++ b/IronSource/IronSourceManager.m
@@ -47,7 +47,7 @@ NSMapTable<NSString *, id<IronSourceInterstitialDelegate>>
 }
 
 - (void)initIronSourceSDKWithAppKey:(NSString *)appKey forAdUnits:(NSSet *)adUnits {
-    if([adUnits member:@[IS_INTERSTITIAL]] != nil){
+    if([adUnits member:IS_INTERSTITIAL] != nil){
         static dispatch_once_t onceTokenIS;
 
         dispatch_once(&onceTokenIS, ^{
@@ -55,7 +55,7 @@ NSMapTable<NSString *, id<IronSourceInterstitialDelegate>>
             [IronSource initISDemandOnly:appKey adUnits:@[IS_INTERSTITIAL]];
         });
     }
-    if([adUnits member:@[IS_REWARDED_VIDEO]] != nil){
+    if([adUnits member:IS_REWARDED_VIDEO] != nil){
         static dispatch_once_t onceTokenRV;
 
         dispatch_once(&onceTokenRV, ^{

--- a/IronSource/IronSourceRewardedVideoCustomEvent.m
+++ b/IronSource/IronSourceRewardedVideoCustomEvent.m
@@ -68,7 +68,7 @@
         MPLogInfo(@"IronSource Rewarded Video initialization with appkey %@", appKey);
         // Cache the initialization parameters
         [IronSourceAdapterConfiguration updateInitializationParameters:info];
-        [[IronSourceManager sharedManager] initIronSourceSDKWithAppKey:appKey forAdUnits:[NSSet setWithObject:@[IS_REWARDED_VIDEO]]];
+        [[IronSourceManager sharedManager] initIronSourceSDKWithAppKey:appKey forAdUnits:[NSSet setWithObject:IS_REWARDED_VIDEO]];
         [self loadRewardedVideo: self.instanceID];
     } @catch (NSException *exception) {
         MPLogInfo(@"IronSource Rewarded Video initialization with error: %@", exception);


### PR DESCRIPTION
There is incorrectness in IronSource SDK initialization which may affect future versions of adapter. IronSource SDK fails to initialize in 
`IronSourceAdapterConfiguration initializeNetworkWithConfiguration:complete:]`

This code passes NSSet with strings into initIronSourceSDKWithAppKey:appKey method
```
[[IronSourceManager sharedManager] initIronSourceSDKWithAppKey:appKey forAdUnits:[NSSet setWithObjects:IS_REWARDED_VIDEO,IS_INTERSTITIAL, nil]];
```

in other places (CustomEvent class) AdUnits NSSet contains NSArray instead of strings:
```
[[IronSourceManager sharedManager] initIronSourceSDKWithAppKey:appKey forAdUnits:[NSSet setWithObject:@[IS_INTERSTITIAL]]];
```