### PR TITLE
Add Metadata tracking to Mopub Adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.podspec
+.DS_Store


### PR DESCRIPTION
**Description:**
This PR is to track metadata while we create, load, and show the interstitial and rewarded ads for instrument analysis. 

**Why?**
Instrument analysis is not added to this adapter yet. Unity can use this information to track the full lifecycle of ads and improve our ad performance and user experience.

**How?**
Initiate a _metadata object using MetaData class and whenever it creates/loads/shows a rewarded or interstitial video, set the category to "mediation_adapter" and set the UUID value to its current action (Eg: load-rewarded).
