### PR TITLE
Chartboost 8.2.0.0 adapters

### DIFF
--- a/Chartboost/CHANGELOG.md
+++ b/Chartboost/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-  * 8.0.4.0
+  * 8.2.0.0
       * This version of the adapters has been certified with Chartboost 8.2.0.
       * Add support for Chartboost CHBDataUseConsent API. 
 

--- a/Chartboost/CHANGELOG.md
+++ b/Chartboost/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## Changelog
+
+  * 8.0.4.0
+      * This version of the adapters has been certified with Chartboost 8.2.0.
+      * Add support for Chartboost CHBDataUseConsent API. 
+
   * 8.1.0.2
       * Refactor non-native adapter classes to use the new consolidated API from MoPub.
       * To use this and newer adapter versions, you must use MoPub 5.13.0 or newer.

--- a/Chartboost/ChartboostAdapterConfiguration.m
+++ b/Chartboost/ChartboostAdapterConfiguration.m
@@ -1,7 +1,7 @@
 #import "ChartboostAdapterConfiguration.h"
 #import "ChartboostRouter.h"
 
-#define CHARTBOOST_ADAPTER_VERSION  @"8.1.0.2"
+#define CHARTBOOST_ADAPTER_VERSION  @"8.2.0.0"
 #define MOPUB_NETWORK_NAME          @"chartboost"
 
 // Constants

--- a/Chartboost/ChartboostBannerCustomEvent.m
+++ b/Chartboost/ChartboostBannerCustomEvent.m
@@ -50,26 +50,14 @@
     // The banner view bounds will have by default the same size as the requested ad size.
     // If the requested width or height is 0, as it happens for the first ad loaded using MoPub's max ad size presets,
     // we change the banner bounds to a standard size, so it is visible.
-    CGSize standardSize = [self standardSizeFromSize:size];
     CGSize bannerSize = banner.bounds.size;
     if (size.width <= 0) {
-        bannerSize.width = standardSize.width;
+        bannerSize.width = CHBBannerSizeStandard.width;
     }
     if (size.height <= 0) {
-        bannerSize.height = standardSize.height;
+        bannerSize.height = CHBBannerSizeStandard.height;
     }
     banner.bounds = CGRectMake(0, 0, bannerSize.width, bannerSize.height);
-}
-
-- (CHBBannerSize)standardSizeFromSize:(CGSize)size
-{
-    if (size.height >= CHBBannerSizeLeaderboard.height && size.width >= CHBBannerSizeLeaderboard.width) {
-        return CHBBannerSizeLeaderboard;
-    } else if (size.height >= CHBBannerSizeMedium.height && size.width >= CHBBannerSizeMedium.width) {
-        return CHBBannerSizeMedium;
-    } else {
-        return CHBBannerSizeStandard;
-    }
 }
 
 - (BOOL)enableAutomaticImpressionAndClickTracking

--- a/Chartboost/ChartboostBannerCustomEvent.m
+++ b/Chartboost/ChartboostBannerCustomEvent.m
@@ -38,10 +38,38 @@
             weakSelf.banner.delegate = nil;
             weakSelf.banner = [[CHBBanner alloc] initWithSize:integerSize location:location mediation:[ChartboostRouter mediation] delegate:weakSelf];
             weakSelf.banner.automaticallyRefreshesContent = NO;
+            [weakSelf setInitialBoundsForBanner:weakSelf.banner size:integerSize];
             
             [weakSelf.banner showFromViewController:[weakSelf.delegate inlineAdAdapterViewControllerForPresentingModalView:weakSelf]];
         });
     }];
+}
+
+- (void)setInitialBoundsForBanner:(CHBBanner *)banner size:(CGSize)size
+{
+    // The banner view bounds will have by default the same size as the requested ad size.
+    // If the requested width or height is 0, as it happens for the first ad loaded using MoPub's max ad size presets,
+    // we change the banner bounds to a standard size, so it is visible.
+    CGSize standardSize = [self standardSizeFromSize:size];
+    CGSize bannerSize = banner.bounds.size;
+    if (size.width <= 0) {
+        bannerSize.width = standardSize.width;
+    }
+    if (size.height <= 0) {
+        bannerSize.height = standardSize.height;
+    }
+    banner.bounds = CGRectMake(0, 0, bannerSize.width, bannerSize.height);
+}
+
+- (CHBBannerSize)standardSizeFromSize:(CGSize)size
+{
+    if (size.height >= CHBBannerSizeLeaderboard.height && size.width >= CHBBannerSizeLeaderboard.width) {
+        return CHBBannerSizeLeaderboard;
+    } else if (size.height >= CHBBannerSizeMedium.height && size.width >= CHBBannerSizeMedium.width) {
+        return CHBBannerSizeMedium;
+    } else {
+        return CHBBannerSizeStandard;
+    }
 }
 
 - (BOOL)enableAutomaticImpressionAndClickTracking

--- a/Chartboost/ChartboostRouter.m
+++ b/Chartboost/ChartboostRouter.m
@@ -45,15 +45,15 @@ static NSString * const kChartboostAppSignatureKey = @"appSignature";
     if ([mopub isGDPRApplicable] == MPBoolYes) {
         if ([mopub allowLegitimateInterest]) {
             if ([mopub currentConsentStatus] == MPConsentStatusDenied || [mopub currentConsentStatus] == MPConsentStatusDoNotTrack) {
-                [Chartboost setPIDataUseConsent:NoBehavioral];
+                [Chartboost addDataUseConsent:[CHBGDPRDataUseConsent gdprConsent:CHBGDPRConsentNonBehavioral]];
             } else {
-                [Chartboost setPIDataUseConsent:YesBehavioral];
+                [Chartboost addDataUseConsent:[CHBGDPRDataUseConsent gdprConsent:CHBGDPRConsentBehavioral]];
             }
         } else {
             if ([mopub canCollectPersonalInfo]) {
-                [Chartboost setPIDataUseConsent:YesBehavioral];
+                [Chartboost addDataUseConsent:[CHBGDPRDataUseConsent gdprConsent:CHBGDPRConsentBehavioral]];
             } else {
-                [Chartboost setPIDataUseConsent:NoBehavioral];
+                [Chartboost addDataUseConsent:[CHBGDPRDataUseConsent gdprConsent:CHBGDPRConsentNonBehavioral]];
             }
         }
     }


### PR DESCRIPTION
Added support for Chartboost 8.2.0, which brings new data use consent APIs.

Also applied a fix to banners layout, since we found that in some cases when the requested ad size width is 0, the chartboost banner view would be invisible due to having 0 width bounds.