### PR TITLE
Release 6.8.0.0 Vungle MoPub Adapter

### DIFF
--- a/Vungle/CHANGELOG.md
+++ b/Vungle/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Changelog
+* 6.8.0.0
+    * This version of the adapters has been certified with Vungle 6.8.0 and MoPub SDK 5.13.1.
+
 * 6.7.1.0
     * This version of the adapters has been certified with Vungle 6.7.1 and MoPub SDK 5.13.1.
     * Fix a Rewarded Video duplicated callbacks issue.

--- a/Vungle/VungleAdapterConfiguration.m
+++ b/Vungle/VungleAdapterConfiguration.m
@@ -41,7 +41,7 @@ typedef NS_ENUM(NSInteger, VungleAdapterErrorCode) {
 #pragma mark - MPAdapterConfiguration
 
 - (NSString *)adapterVersion {
-    return @"6.7.1.0";
+    return @"6.8.0.0";
 }
 
 - (NSString *)biddingToken {


### PR DESCRIPTION
This version of the adapters has been certified with Vungle 6.8.0 and MoPub SDK 5.13.1.