### PR TITLE
IronSourceManager initIronSourceSDKWithAppKey compare adUnits values …

### DIFF
--- a/IronSource/IronSourceAdapterConfiguration.m
+++ b/IronSource/IronSourceAdapterConfiguration.m
@@ -50,7 +50,11 @@ NSString * const kIronSourceAppkey = @"applicationKey";
 
 - (void)initializeNetworkWithConfiguration:(NSDictionary<NSString *, id> *)configuration
                                   complete:(void(^)(NSError *))complete {
-    NSString * appKey = configuration[kIronSourceAppKey];
+    NSString *appKey = configuration[kIronSourceAppKey];
+    NSString *rewardedVideoStatus = configuration[IS_REWARDED_VIDEO];
+    NSString *interstitialStatus = configuration[IS_INTERSTITIAL];
+    BOOL shouldInit = TRUE;
+    NSMutableSet *adUnitsSet = [NSMutableSet set];
     if ([appKey length] == 0) {
         MPLogInfo(@"IronSource Adapter failed to initialize, 'applicationKey' parameter is missing. Make sure that 'applicationKey' server parameter is added");
         
@@ -59,13 +63,28 @@ NSString * const kIronSourceAppkey = @"applicationKey";
         }
         return;
     }
+        
+    if(rewardedVideoStatus != nil && [rewardedVideoStatus isKindOfClass:[NSString class]]) {
+        if([rewardedVideoStatus boolValue]) {
+            [adUnitsSet addObject:IS_REWARDED_VIDEO];
+        }
+    }
     
-    MPLogInfo(@"Initializing IronSource with appkey %@", appKey);
-    dispatch_async(dispatch_get_main_queue(), ^{
-    [IronSource setMediationType:[NSString stringWithFormat:@"%@%@SDK%@",
-                                  kIronSourceMediationName,kIronSourceMediationVersion, [IronSourceUtils getMoPubSdkVersion]]];
-    [[IronSourceManager sharedManager] initIronSourceSDKWithAppKey:appKey forAdUnits:[NSSet setWithObjects:IS_REWARDED_VIDEO,IS_INTERSTITIAL, nil]];
-    });
+    if(interstitialStatus != nil && [rewardedVideoStatus isKindOfClass:[NSString class]]) {
+        if([interstitialStatus boolValue]) {
+            [adUnitsSet addObject:IS_INTERSTITIAL];
+        }
+    }
+    
+    MPLogInfo(@"IronSource adUnits to init are %@" , [adUnitsSet allObjects]);
+    if(shouldInit) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [IronSource setMediationType:[NSString stringWithFormat:@"%@%@SDK%@",
+                                          kIronSourceMediationName,kIronSourceMediationVersion, [IronSourceUtils getMoPubSdkVersion]]];
+            [[IronSourceManager sharedManager] initIronSourceSDKWithAppKey:appKey forAdUnits: adUnitsSet];
+        });
+    }
+    
     if (complete != nil) {
         complete(nil);
     }

--- a/IronSource/IronSourceConstants.h
+++ b/IronSource/IronSourceConstants.h
@@ -4,7 +4,7 @@
 
 // IronSource internal reporting consts
 static NSString *const kIronSourceMediationName = @"mopub";
-static NSString *const kIronSourceMediationVersion = @"400";
+static NSString *const kIronSourceMediationVersion = @"500";
 // IronSource parameters keys
 static NSString *const kIronSourceAppKey        = @"applicationKey";
 static NSString *const kIronSourceInstanceId    = @"instanceId";

--- a/IronSource/IronSourceInterstitialCustomEvent.m
+++ b/IronSource/IronSourceInterstitialCustomEvent.m
@@ -73,7 +73,7 @@
             MPLogInfo(@"IronSource Interstitial initialization with appkey %@", appKey);
             // Cache the initialization parameters
             [IronSourceAdapterConfiguration updateInitializationParameters:info];
-            [[IronSourceManager sharedManager] initIronSourceSDKWithAppKey:appKey forAdUnits:[NSSet setWithObject:@[IS_INTERSTITIAL]]];
+            [[IronSourceManager sharedManager] initIronSourceSDKWithAppKey:appKey forAdUnits:[NSSet setWithObject:IS_INTERSTITIAL]];
             [self loadInterstitial:self.instanceId WithAdMarkup:adMarkup];
         } else {
             MPLogInfo(@"IronSource Interstitial initialization with empty or nil appKey for instance %@",

--- a/IronSource/IronSourceManager.m
+++ b/IronSource/IronSourceManager.m
@@ -47,22 +47,22 @@ NSMapTable<NSString *, id<IronSourceInterstitialDelegate>>
 }
 
 - (void)initIronSourceSDKWithAppKey:(NSString *)appKey forAdUnits:(NSSet *)adUnits {
-    if([adUnits member:@[IS_INTERSTITIAL]] != nil){
-        static dispatch_once_t onceTokenIS;
-
-        dispatch_once(&onceTokenIS, ^{
-            [IronSource setISDemandOnlyInterstitialDelegate:self];
-            [IronSource initISDemandOnly:appKey adUnits:@[IS_INTERSTITIAL]];
-        });
-    }
-    if([adUnits member:@[IS_REWARDED_VIDEO]] != nil){
-        static dispatch_once_t onceTokenRV;
-
-        dispatch_once(&onceTokenRV, ^{
-            [IronSource setISDemandOnlyRewardedVideoDelegate:self];
-            [IronSource initISDemandOnly:appKey adUnits:@[IS_REWARDED_VIDEO]];
-        });
-    }
+        if([adUnits member:IS_INTERSTITIAL] != nil) {
+            static dispatch_once_t onceTokenIS;
+            
+            dispatch_once(&onceTokenIS, ^{
+                [IronSource setISDemandOnlyInterstitialDelegate:self];
+            });
+        }
+        if([adUnits member:IS_REWARDED_VIDEO] != nil){
+            static dispatch_once_t onceTokenRV;
+            
+            dispatch_once(&onceTokenRV, ^{
+                [IronSource setISDemandOnlyRewardedVideoDelegate:self];
+            });
+        }
+        
+        [IronSource initISDemandOnly:appKey adUnits:[adUnits allObjects]];
 }
 
 - (void)loadRewardedAdWithDelegate:

--- a/IronSource/IronSourceRewardedVideoCustomEvent.m
+++ b/IronSource/IronSourceRewardedVideoCustomEvent.m
@@ -88,7 +88,7 @@
         MPLogInfo(@"IronSource Rewarded Video initialization with appkey %@", appKey);
         // Cache the initialization parameters
         [IronSourceAdapterConfiguration updateInitializationParameters:info];
-        [[IronSourceManager sharedManager] initIronSourceSDKWithAppKey:appKey forAdUnits:[NSSet setWithObject:@[IS_REWARDED_VIDEO]]];
+        [[IronSourceManager sharedManager] initIronSourceSDKWithAppKey:appKey forAdUnits:[NSSet setWithObject:IS_REWARDED_VIDEO]];
         [self loadRewardedVideo: self.instanceID WithAdMarkup: adMarkup];
     } @catch (NSException *exception) {
         MPLogInfo(@"IronSource Rewarded Video initialization with error: %@", exception);


### PR DESCRIPTION
…to constant strings, Remove string literal from NSSet that sent to initIronSourceSDKWithAppKey on RewardedVideoCustomEvent and InterstitialCustomEvent,

Increase kIronSourceMediationVersion,
networkConfiguration can contain ad units to init for IronSource