### PR TITLE
Ad show metadata

### DIFF
--- a/UnityAds/UnityAdsInterstitialCustomEvent.m
+++ b/UnityAds/UnityAdsInterstitialCustomEvent.m
@@ -20,6 +20,8 @@ static NSString *const kUnityAdsOptionZoneIdKey = @"zoneId";
 @interface UnityAdsInterstitialCustomEvent () <UnityAdsLoadDelegate, UnityAdsExtendedDelegate>
 
 @property (nonatomic, copy) NSString *placementId;
+@property (nonatomic) int impressionOrdinal;
+@property (nonatomic) int missedImpressionOrdinal;
 
 @end
 
@@ -214,10 +216,10 @@ int missedImpressionOrdinal;
 - (void) sendMetadataAdShownCorrect: (BOOL) isAdShown {
     UADSMediationMetaData *headerBiddingMeta = [[UADSMediationMetaData alloc]initWithCategory:@"mediation"];
     if(isAdShown) {
-        [headerBiddingMeta setOrdinal: ++impressionOrdinal];
+        [headerBiddingMeta setOrdinal: ++_impressionOrdinal];
     }
     else {
-        [headerBiddingMeta setMissedImpressionOrdinal: ++missedImpressionOrdinal];
+        [headerBiddingMeta setMissedImpressionOrdinal: ++_missedImpressionOrdinal];
     }
     [headerBiddingMeta commit];
 }

--- a/UnityAds/UnityAdsInterstitialCustomEvent.m
+++ b/UnityAds/UnityAdsInterstitialCustomEvent.m
@@ -28,6 +28,9 @@ static NSString *const kUnityAdsOptionZoneIdKey = @"zoneId";
 @dynamic localExtras;
 @dynamic hasAdAvailable;
 
+int impressionOrdinal;
+int missedImpressionOrdinal;
+
 #pragma mark - MPFullscreenAdAdapter Override
 
 - (BOOL)isRewardExpected {
@@ -196,6 +199,7 @@ static NSString *const kUnityAdsOptionZoneIdKey = @"zoneId";
 - (void)unityAdsAdLoaded:(NSString *)placementId {
     [self.delegate fullscreenAdAdapterDidLoadAd:self];
     MPLogAdEvent([MPLogEvent adLoadSuccessForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
+    [self sendMetadataAdShownCorrect:YES];
 }
 
 - (void)unityAdsAdFailedToLoad:(nonnull NSString *)placementId {
@@ -204,6 +208,18 @@ static NSString *const kUnityAdsOptionZoneIdKey = @"zoneId";
                                  andSuggestion:@""];
     MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:errorLoad], [self getAdNetworkId]);
     [self.delegate fullscreenAdAdapter:self didFailToLoadAdWithError:errorLoad];
+    [self sendMetadataAdShownCorrect:NO];
+}
+
+- (void) sendMetadataAdShownCorrect: (BOOL) isAdShown {
+    UADSMediationMetaData *headerBiddingMeta = [[UADSMediationMetaData alloc]initWithCategory:@"mediation"];
+    if(isAdShown) {
+        [headerBiddingMeta setOrdinal: ++impressionOrdinal];
+    }
+    else {
+        [headerBiddingMeta setMissedImpressionOrdinal: ++missedImpressionOrdinal];
+    }
+    [headerBiddingMeta commit];
 }
 
 @end

--- a/UnityAds/UnityAdsRewardedVideoCustomEvent.m
+++ b/UnityAds/UnityAdsRewardedVideoCustomEvent.m
@@ -22,6 +22,8 @@ static NSString *const kUnityAdsOptionZoneIdKey = @"zoneId";
 @interface UnityAdsRewardedVideoCustomEvent () <UnityAdsLoadDelegate, UnityAdsExtendedDelegate>
 
 @property (nonatomic, copy) NSString *placementId;
+@property (nonatomic) int impressionOrdinal;
+@property (nonatomic) int missedImpressionOrdinal;
 
 @end
 
@@ -29,9 +31,6 @@ static NSString *const kUnityAdsOptionZoneIdKey = @"zoneId";
 @dynamic delegate;
 @dynamic localExtras;
 @dynamic hasAdAvailable;
-
-int impressionOrdinal;
-int missedImpressionOrdinal;
 
 - (void)initializeSdkWithParameters:(NSDictionary *)parameters {
     NSString *gameId = [parameters objectForKey:kMPUnityRewardedVideoGameId];
@@ -220,10 +219,10 @@ int missedImpressionOrdinal;
 - (void) sendMetadataAdShownCorrect: (BOOL) isAdShown {
     UADSMediationMetaData *headerBiddingMeta = [[UADSMediationMetaData alloc]initWithCategory:@"mediation"];
     if(isAdShown) {
-        [headerBiddingMeta setOrdinal: ++impressionOrdinal];
+        [headerBiddingMeta setOrdinal: ++_impressionOrdinal];
     }
     else {
-        [headerBiddingMeta setMissedImpressionOrdinal: ++missedImpressionOrdinal];
+        [headerBiddingMeta setMissedImpressionOrdinal: ++_missedImpressionOrdinal];
     }
     [headerBiddingMeta commit];
 }

--- a/UnityAds/UnityAdsRewardedVideoCustomEvent.m
+++ b/UnityAds/UnityAdsRewardedVideoCustomEvent.m
@@ -30,6 +30,9 @@ static NSString *const kUnityAdsOptionZoneIdKey = @"zoneId";
 @dynamic localExtras;
 @dynamic hasAdAvailable;
 
+int impressionOrdinal;
+int missedImpressionOrdinal;
+
 - (void)initializeSdkWithParameters:(NSDictionary *)parameters {
     NSString *gameId = [parameters objectForKey:kMPUnityRewardedVideoGameId];
     if (gameId == nil) {
@@ -205,11 +208,24 @@ static NSString *const kUnityAdsOptionZoneIdKey = @"zoneId";
     NSError *error = [NSError errorWithDomain:MoPubRewardedVideoAdsSDKDomain code:MPRewardedVideoAdErrorUnknown userInfo:nil];
     MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:error], [self getAdNetworkId]);
      [self.delegate fullscreenAdAdapter:self didFailToLoadAdWithError:error];
+    [self sendMetadataAdShownCorrect:NO];
 }
 
 - (void)unityAdsAdLoaded:(nonnull NSString *)placementId {
     MPLogAdEvent([MPLogEvent adLoadSuccessForAdapter:NSStringFromClass(self.class)], [self getAdNetworkId]);
     [self.delegate fullscreenAdAdapterDidLoadAd:self];
+    [self sendMetadataAdShownCorrect:YES];
+}
+
+- (void) sendMetadataAdShownCorrect: (BOOL) isAdShown {
+    UADSMediationMetaData *headerBiddingMeta = [[UADSMediationMetaData alloc]initWithCategory:@"mediation"];
+    if(isAdShown) {
+        [headerBiddingMeta setOrdinal: ++impressionOrdinal];
+    }
+    else {
+        [headerBiddingMeta setMissedImpressionOrdinal: ++missedImpressionOrdinal];
+    }
+    [headerBiddingMeta commit];
 }
 
 @end


### PR DESCRIPTION
Android version of mopub mediation uses metadata to send successfull ad shown and ad failed to shown. Added this to ios. 