### PR TITLE
Fix race condition between rect and banner request

### DIFF
--- a/AdMob/CHANGELOG.md
+++ b/AdMob/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Changelog
+  * 7.69.0.3
+    * Fix static banner size leaking to subsequent adapter instances.
+
   * 7.69.0.2
     * Add support for `fullscreenAdAdapterAdWillDismiss` when a fullscreen creative is about to close. Publishers must use v5.16.1 of the MoPub SDK at the minimum.
 

--- a/AdMob/GoogleAdMobAdapterConfiguration.m
+++ b/AdMob/GoogleAdMobAdapterConfiguration.m
@@ -40,7 +40,7 @@ typedef NS_ENUM(NSInteger, AdMobAdapterErrorCode) {
 #pragma mark - MPAdapterConfiguration
 
 - (NSString *)adapterVersion {
-    return @"7.69.0.2";
+    return @"7.69.0.3";
 }
 
 - (NSString *)biddingToken {

--- a/AdMob/MPGoogleAdMobBannerCustomEvent.m
+++ b/AdMob/MPGoogleAdMobBannerCustomEvent.m
@@ -18,14 +18,13 @@
 
 @property(nonatomic, strong) GADBannerView *adBannerView;
 
+@property(nonatomic) CGSize adSize;
+
 @end
 
 @implementation MPGoogleAdMobBannerCustomEvent
 @dynamic delegate;
 @dynamic localExtras;
-
-CGFloat adWidth;
-CGFloat adHeight;
 
 - (id)init {
   self = [super init];
@@ -45,10 +44,9 @@ CGFloat adHeight;
 }
 
 - (void)requestAdWithSize:(CGSize)size adapterInfo:(NSDictionary *)info adMarkup:(NSString *)adMarkup {
-  adWidth = size.width;
-  adHeight = size.height;
+  self.adSize = size;
     
-  if (adWidth <= 0.0 || adHeight <= 0.0) {
+  if (self.adSize.width <= 0.0 || self.adSize.height <= 0.0) {
     NSString *failureReason = @"Google AdMob banner failed to load due to invalid ad width and/or height.";
     NSError *mopubError = [NSError errorWithCode:MOPUBErrorAdapterInvalid localizedDescription:failureReason];
 
@@ -58,7 +56,7 @@ CGFloat adHeight;
     return;
   }
     
-  self.adBannerView.frame = CGRectMake(0, 0, adWidth, adHeight);
+  self.adBannerView.frame = (CGRect){CGPointZero, self.adSize};
   self.adBannerView.adUnitID = [info objectForKey:@"adUnitID"];
   self.adBannerView.rootViewController = [self.delegate inlineAdAdapterViewControllerForPresentingModalView:self];
     
@@ -107,8 +105,8 @@ CGFloat adHeight;
   CGFloat receivedWidth = bannerView.adSize.size.width;
   CGFloat receivedHeight = bannerView.adSize.size.height;
     
-  if (receivedWidth > adWidth || receivedHeight > adHeight) {
-    NSString *failureReason = [NSString stringWithFormat:@"Google served an ad but it was invalidated because its size of %.0f x %.0f exceeds the publisher-specified size of %.0f x %.0f", receivedWidth, receivedHeight, adWidth, adHeight];
+  if (receivedWidth > self.adSize.width || receivedHeight > self.adSize.height) {
+    NSString *failureReason = [NSString stringWithFormat:@"Google served an ad but it was invalidated because its size of %.0f x %.0f exceeds the publisher-specified size of %.0f x %.0f", receivedWidth, receivedHeight, self.adSize.width, self.adSize.height];
     NSError *mopubError = [NSError errorWithCode:MOPUBErrorAdapterInvalid localizedDescription:failureReason];
 
     MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:mopubError], [self getAdNetworkId]);


### PR DESCRIPTION
Requesting a rect then immediately a banner can result in ignoring the mrect response as the banner size was kept in two static variables