### PR TITLE
AppLovin set mediation provider/plugin version in AppLovinAdapterConfiguration

### DIFF
--- a/AppLovin/AppLovinAdapterConfiguration.m
+++ b/AppLovin/AppLovinAdapterConfiguration.m
@@ -60,6 +60,8 @@ typedef NS_ENUM(NSInteger, AppLovinAdapterErrorCode)
     if ( sdk )
     {
         AppLovinAdapterConfigurationSDK = sdk;
+        sdk.mediationProvider = ALMediationProviderMoPub;
+        [sdk setPluginVersion: AppLovinAdapterConfiguration.pluginVersion];
     }
     // If SDK could not be retrieved, it means SDK key was missing from `configuration` (cached or not) AND the Info.plist
     else


### PR DESCRIPTION
Ensure mediation provider and plugin version are always set when the AppLovin SDK is accessed.
This also brings it in line with the Android adapter which already does this: https://github.com/mopub/mopub-android-mediation/blob/827c62f45e211b712d95aa45eee5790ea14827cc/AppLovin/src/main/java/com/mopub/mobileads/AppLovinAdapterConfiguration.java#L71