### PR TITLE
Release Vungle - 6.9.2.0

### DIFF
--- a/Vungle/CHANGELOG.md
+++ b/Vungle/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Changelog
+* 6.9.2.0
+  * This version of the adapters has been certified with Vungle 6.9.2.
+  
 * 6.9.1.2
   * Address Vungle SDK v6.9.1 deadlock issue.
   

--- a/Vungle/VungleAdapterConfiguration.m
+++ b/Vungle/VungleAdapterConfiguration.m
@@ -46,7 +46,7 @@ typedef NS_ENUM(NSInteger, VungleAdapterErrorCode) {
 #pragma mark - MPAdapterConfiguration
 
 - (NSString *)adapterVersion {
-    return @"6.9.1.2";
+    return @"6.9.2.0";
 }
 
 - (NSString *)biddingToken {


### PR DESCRIPTION
This version of the adapters has been certified with Vungle 6.9.2.